### PR TITLE
activate CI, add secondary axes and automatic filetype deduction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,10 @@ install:
   - sh init.sh -y
   - export PATH=$HOME/.nimble/bin:$PATH
   - nimble refresh -y
-  - git clone https://github.com/Vindaar/chroma#addMoreSpaces
+  - git clone https://github.com/Vindaar/chroma
   - pushd chroma
+  - git fetch origin
+  - git checkout -t origin/addMoreSpaces
   - nimble develop -y
   - popd
   - choosenim $CHANNEL

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+sudo: required
+
+os:
+  - linux
+
+language: c
+dist: xenial
+
+matrix:
+  include:
+    # Build and test against the master (stable) and devel branches of Nim
+    # Build and test using both gcc and clang
+    - os: linux
+      env: CHANNEL=stable
+      compiler: gcc
+
+    - os: linux
+      env: CHANNEL=devel
+      compiler: gcc
+
+cache:
+  directories:
+    - "$HOME/.nimble"
+    - "$HOME/.choosenim"
+
+addons:
+  apt:
+     packages:
+       - libcairo2
+       - libcairo2-dev
+
+install:
+  - curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh
+  - sh init.sh -y
+  - export PATH=$HOME/.nimble/bin:$PATH
+  - nimble refresh -y
+  - nimble install -y "https://github.com/Vindaar/chroma#addMoreSpaces"
+  - choosenim $CHANNEL
+
+script:
+  - nimble install -y
+  - nimble -y test

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,10 @@ install:
   - sh init.sh -y
   - export PATH=$HOME/.nimble/bin:$PATH
   - nimble refresh -y
-  - nimble install -y "https://github.com/Vindaar/chroma#addMoreSpaces"
+  - git clone https://github.com/Vindaar/chroma#addMoreSpaces
+  - pushd chroma
+  - nimble develop -y
+  - popd
   - choosenim $CHANNEL
 
 script:

--- a/ginger.nimble
+++ b/ginger.nimble
@@ -12,3 +12,6 @@ srcDir        = "src"
 requires "nim >= 0.19.9"
 # requires "https://github.com/Vindaar/chroma#addMoreSpaces"
 requires "cairo"
+
+task test, "Run tests":
+  exec "nim c -r tests/test1.nim"

--- a/ginger.nimble
+++ b/ginger.nimble
@@ -11,6 +11,7 @@ srcDir        = "src"
 
 requires "nim >= 0.19.9"
 # requires "https://github.com/Vindaar/chroma#addMoreSpaces"
+requires "https://github.com/vindaar/seqmath#head"
 requires "cairo"
 
 task test, "Run tests":

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -2393,9 +2393,22 @@ proc draw(img: BImage, view: Viewport) =
     mchView.rotate = view.rotate
     img.draw(mchView)
 
-proc draw*(view: Viewport, filename: string, ftype = fkPdf) =
+proc parseFilename(fname: string): FiletypeKind =
+  let (_, _, ext) = fname.splitFile
+  case ext.normalize
+  of ".pdf":
+    result = fkPdf
+  of ".svg":
+    result = fkSvg
+  of ".png":
+    result = fkPng
+  else:
+    result = fkPdf
+
+proc draw*(view: Viewport, filename: string) =
   ## draws the given viewport and all its children and stores it in the
   ## file `filename`
+  let ftype = parseFilename(filename)
   var img = initBImage(filename,
                        width = view.wImg.val.round.int, height = view.hImg.val.round.int,
                        backend = view.backend,

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -2285,8 +2285,8 @@ proc drawPolyLine(img: BImage, gobj: GraphObject) =
 
 proc drawText(img: BImage, gobj: GraphObject) =
   doAssert(
-    (gobj.kind == goText or gobj.kind == goLabel),
-    "object must be a `goText` or `goLabel`!"
+    (gobj.kind == goText or gobj.kind == goLabel or gobj.kind == goTickLabel),
+    "object must be a `goText`, `goLabel` or `goTickLabel`!"
   )
   img.drawText(gobj.txtText, gobj.txtFont, gobj.txtPos.point, gobj.txtAlign,
                gobj.rotate)
@@ -2385,7 +2385,7 @@ proc toGlobalCoords(gobj: GraphObject, img: BImage): GraphObject =
     result.ptPos = gobj.ptPos.toAbsImage(img)
   of goPolyLine:
     result.plPos = gobj.plPos.mapIt(it.toAbsImage(img))
-  of goText, goLabel:
+  of goText, goLabel, goTickLabel:
     result.txtPos = gobj.txtPos.toAbsImage(img)
   of goTick:
     result.tkPos = gobj.tkPos.toAbsImage(img)
@@ -2400,8 +2400,6 @@ proc toGlobalCoords(gobj: GraphObject, img: BImage): GraphObject =
   of goComposite:
     # composite has nothing to be drawn, only children, which are handled individually
     discard
-  else:
-    raise newException(Exception, "Not yet implemented!")
 
 proc draw*(img: BImage, gobj: GraphObject) =
   ## draws the given graph object on the image
@@ -2412,25 +2410,19 @@ proc draw*(img: BImage, gobj: GraphObject) =
     img.drawLine(globalObj)
   of goRect:
     img.drawRect(globalObj)
-  #of goLabel:
-  #  img.drawLabel(gobj)
   of goPoint:
     img.drawPoint(globalObj)
   of goPolyLine:
     img.drawPolyLine(globalObj)
-  of goLabel, goText:
+  of goLabel, goText, goTickLabel:
     img.drawText(globalObj)
   of goTick:
     img.drawTick(globalObj)
   of goGrid:
     img.drawGrid(globalObj)
-  #of goLine:
-  #  img.drawLine(gobj)
   of goComposite:
     # composite itself has nothing to be drawn, only children handled individually
     discard
-  else:
-    raise newException(Exception, "Not implemented yet!")
 
 iterator items*(view: Viewport): Viewport =
   for ch in view.children:
@@ -2454,7 +2446,7 @@ proc embedInto(gobj: GraphObject, view: Viewport): GraphObject =
     result.ptPos = gobj.ptPos.embedInto(view)
   of goPolyLine:
     result.plPos = gobj.plPos.mapIt(it.embedInto(view))
-  of goLabel, goText:
+  of goLabel, goText, goTickLabel:
     result.txtPos = gobj.txtPos.embedInto(view)
   of goTick:
     result.tkPos = gobj.tkPos.embedInto(view)
@@ -2469,8 +2461,9 @@ proc embedInto(gobj: GraphObject, view: Viewport): GraphObject =
     # composite itself contains nothing to draw, only children.
     # children will be drawn and embedded individually
     discard
-  else:
-    raise newException(Exception, "embedInto not implemented yet!")
+  #else:
+  #  raise newException(Exception, "embedInto not implemented yet for " &
+  #    $gobj.kind & "!")
 
 proc getCenter*(view: Viewport): (float, float) =
   ## returns the center position of the given viewport in relative coordinates

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -12,6 +12,8 @@ import strutils
 import ginger / [macroUtils, backends, types]
 export types, backends, macroUtils
 
+from os import splitFile
+
 # TODO: think about renaming `Coord1D` to someting like Unit?
 
 # TODO: implement some more units so that we can use it to define

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -1303,11 +1303,13 @@ proc initRect*(view: Viewport,
 proc initText*(view: Viewport,
                origin: Coord,
                text: string,
+               textKind: static GraphObjectKind,
                alignKind: TextAlignKind,
                font: Option[Font] = none[Font](),
                rotate = none[float](),
                name = "text"): GraphObject =
-  result = GraphObject(kind: goText,
+  assert textKind in {goText, goLabel, goTickLabel}
+  result = GraphObject(kind: textKind,
                        name: name,
                        txtText: text,
                        txtAlign: alignKind,
@@ -1536,7 +1538,7 @@ proc initAxisLabel[T: Quantity | Coord1D](view: Viewport,
   if marginVal < marginMin and not isCustomMargin:
     marginVal = marginMin
 
-  result = GraphObject(kind: goText,
+  result = GraphObject(kind: goLabel,
                        name: name,
                        txtText: label,
                        txtAlign: taCenter)
@@ -2527,6 +2529,7 @@ when isMainModule:
 
     let text = view2.initText(initCoord(0.5, 1.05),
                               "Hello",
+                              textKind = goText,
                               alignKind = taCenter,
                               font = some(Font(family: "serif",
                                    size: 12.0,
@@ -2535,6 +2538,7 @@ when isMainModule:
 
     let textRot = view2.initText(initCoord(-0.05, 0.5),
                                  "Counts",
+                                 textKind = goText,
                                  alignKind = taCenter,
                                  font = some(Font(family: "serif",
                                              size: 12.0,

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -6,68 +6,84 @@
 # To run these tests, simply execute `nimble test`.
 
 import unittest
-import sequtils
+import sequtils, math
 
 import ginger
-#suite "Coordinate transformations":
-#  test "Simple coordinate equalities":
-#    # some simple tests for `toRelative` coord trafo
-#    let
-#      c1Rel = Coord(x: Coord1D(pos: 0.5, kind: ukRelative),
-#                    y: Coord1D(pos: 0.2, kind: ukRelative))
-#      c1Abs = Coord(x: (Coord1D(pos: 300, length: some(600.0), kind: ukAbsolute)),
-#                    y: (Coord1D(pos: 100, length: some(400.0), kind: ukAbsolute)))
-#      c2Rel = Coord(x: Coord1D(pos: 0.5, kind: ukRelative),
-#                    y: Coord1D(pos: 0.25, kind:ukRelative))
-#      c1Dat = Coord(x: (Coord1D(pos: 300, scale: (low: 100.0, high: 500.0), kind: ukData)),
-#                    y: (Coord1D(pos: 100, scale: (low: 0.0, high: 500.0), kind: ukData)))
-#      c2Dat = Coord(x: (Coord1D(pos: 300, scale: (low: -100.0, high: 300.0), kind: ukData)),
-#                    y: (Coord1D(pos: 100, scale: (low: -200.0, high: 200.0), kind: ukData)))
-#      c3Rel = Coord(x: Coord1D(pos: 1.0, kind: ukRelative),
-#                    y: Coord1D(pos: 0.75, kind:ukRelative))
-#    check c1Rel.toRelative == c1Rel
-#    check c1Abs.toRelative == c2Rel
-#    check c1Dat.toRelative == c1Rel
-#    check c2Dat.toRelative == c3Rel
-#
-#    check c2Rel.to(
-#      ukAbsolute,
-#      absWidth = some(600.0),
-#      absHeight = some(400.0)
-#    ) == c1Abs
-#    check c1Abs.to(
-#      ukData,
-#      datxScale = some((low: 100.0, high: 500.0)),
-#      datyScale = some((low: 0.0, high: 400.0))
-#    ) == c2Rel
-#    check c1Abs.to(
-#      ukData,
-#      datxScale = some((low: 100.0, high: 500.0)),
-#      datyScale = some((low: 0.0, high: 400.0)))
-#    .to(
-#      ukAbsolute,
-#      absWidth = c1Abs.x.length,
-#      absHeight =c1Abs.y.length
-#    ) == c1Abs
-#
-#  test "Unit conversions":
-#    let
-#      c1cm = initCoord1D(2.54, ukCentimeter)
-#      c1in = initCoord1D(1.0, ukInch)
-#      c1pt = initCoord1D(72.27, ukAbsolute)
-#    check c1cm == c1in
-#    check c1cm == c1pt
-#    check c1in == c1pt
-#
-#  test "Unit to relative conversions":
-#    let
-#      c1cm = initCoord1D(1.0, ukCentimeter)
-#      c1in = initCoord1D(1.0, ukInch)
-#      c1pt = initCoord1D(1.0, ukAbsolute)
-#      # floating point error due to conversion
-#      c1Rel = initCoord1D(0.09999999999999999)
-#    check c1cm.toRelative(length = some(722.7 / 2.54)) == c1Rel
-#    check c1in.toRelative(length = some(722.7)) == c1Rel
+
+
+func almostEqual(c1, c2: Coord1D, eps = 1e-5): bool =
+  result = abs(c1.pos - c2.pos) < eps
+
+func almostEqual(c1, c2: Quantity, eps = 1e-5): bool =
+  result = abs(c1.val - c2.val) < eps
+
+func almostEqual(c1, c2: Coord, eps = 1e-5): bool =
+  result = abs(c1.x.pos - c2.x.pos) < eps and abs(c1.y.pos - c2.y.pos) < eps
+
+suite "Coordinate transformations":
+  test "Simple coordinate equalities":
+    # some simple tests for `toRelative` coord trafo
+    let
+      c1Rel = Coord(x: Coord1D(pos: 0.5, kind: ukRelative),
+                    y: Coord1D(pos: 0.2, kind: ukRelative))
+      c1Abs = Coord(x: Coord1D(pos: 300, length: some(quant(600.0, ukPoint)), kind: ukPoint),
+                    y: Coord1D(pos: 100, length: some(quant(400.0, ukPoint)), kind: ukPoint))
+      c2Rel = Coord(x: Coord1D(pos: 0.5, kind: ukRelative),
+                    y: Coord1D(pos: 0.25, kind:ukRelative))
+      c1Dat = Coord(x: (Coord1D(pos: 300, scale: (low: 100.0, high: 500.0), kind: ukData)),
+                    y: (Coord1D(pos: 100, scale: (low: 0.0, high: 500.0), kind: ukData)))
+      c2Dat = Coord(x: (Coord1D(pos: 300, scale: (low: -100.0, high: 300.0), kind: ukData)),
+                    y: (Coord1D(pos: 100, scale: (low: -200.0, high: 200.0), kind: ukData)))
+      c3Rel = Coord(x: Coord1D(pos: 1.0, kind: ukRelative),
+                    y: Coord1D(pos: 0.75, kind:ukRelative))
+    check almostEqual(c1Rel.toRelative, c1Rel)
+    check almostEqual(c1Abs.toRelative, c2Rel)
+    check almostEqual(c1Dat.toRelative, c1Rel)
+    check almostEqual(c2Dat.toRelative, c3Rel)
+
+    check c2Rel.to(
+      ukPoint,
+      absWidth = some(quant(600.0, ukPoint)),
+      absHeight = some(quant(400.0, ukPoint))
+    ) == c1Abs
+    check c1Abs.to(
+      ukData,
+      datxScale = some((low: 100.0, high: 500.0)),
+      datyScale = some((low: 0.0, high: 400.0))
+    ) == c2Rel
+    check c1Abs.to(
+      ukData,
+      datxScale = some((low: 100.0, high: 500.0)),
+      datyScale = some((low: 0.0, high: 400.0)))
+    .to(
+      ukPoint,
+      absWidth = c1Abs.x.length,
+      absHeight =c1Abs.y.length
+    ) == c1Abs
+
+  test "Quantity comparisons":
+    let
+      qcm = quant(2.54, ukCentimeter)
+      qin = quant(1.0, ukInch)
+      qpt = quant(72.27, ukPoint)
+    check almostEqual(qcm, qin.toCentimeter)
+    check almostEqual(qcm, qpt.toCentimeter)
+    check almostEqual(qin, qpt.toInch)
+
+  test "Unit to relative conversions":
+    let
+      c1cm = initCoord1D(1.0, ukCentimeter)
+      c1in = initCoord1D(1.0, ukInch)
+      c1pt = initCoord1D(1.0, ukPoint)
+      # floating point error due to conversion
+      c1Rel = initCoord1D(0.09999999999999999)
+    check almostEqual(c1cm.toRelative(length = some(quant(722.7 / 2.54, ukPoint))), c1Rel)
+    check almostEqual(c1in.toRelative(length = some(quant(722.7, ukPoint))), c1Rel)
+
+suite "Embeddings":
+  test "Dummy":
+    # TODO: have to write a lot more test, which test coordinatees under embeddings!
+    # As far as I'm aware there are still some bugs lurking here :/
 
 suite "Viewport":
   test "Mutable children":

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -188,3 +188,86 @@ suite "Viewport":
       check p.ptPos.y.kind == ukData
       check p.ptPos.x.scale == (low: 0.0, high: 1000.0)
       check p.ptPos.y.scale == yScale
+
+  test "Axes and labels":
+    var view = initViewport()
+    let x = toSeq(0 .. 958).mapIt(it.float)
+    let y = x.mapIt(it.float * it.float)
+    let xScale = (low: 0.0, high: x.max)
+    let yScale = (low: 0.0, high: y.max)
+    var child = initViewport(left = 0.15,
+                             bottom = 0.4,
+                             width = 0.75,
+                             height = 0.5,
+                             xScale = some(xScale),
+                             yScale = some(yScale))
+    var oldChild = child
+    block:
+      # x ticks and labels
+      var mch = oldChild
+      let xTicks = child.xticks()
+      let xLabel = child.xlabel("X label")
+      mch.addObj concat(xticks, @[xlabel])
+      child.addObj concat(xticks, @[xlabel])
+      for ch in mch.objects:
+        case ch.kind:
+        of goTick:
+          check ch.tkAxis == akX
+          check ch.tkPos.y == XAxisYPos()
+        of goLabel:
+          check ch.txtText == "X label"
+          check ch.txtPos.y.pos.round.int == 283
+        else: check false
+
+    block:
+      # x ticks and labels
+      var mch = oldChild
+      let yTicks = child.yticks()
+      let yLabel = child.ylabel("Y label")
+      mch.addObj concat(yticks, @[ylabel])
+      child.addObj concat(yticks, @[ylabel])
+      for ch in mch.objects:
+        case ch.kind:
+        of goTick:
+          check ch.tkAxis == akY
+          check ch.tkPos.x == YAxisXPos()
+        of goLabel:
+          check ch.txtText == "Y label"
+          check ch.txtPos.x.pos.round.int == -43
+        else: check false
+    block:
+      # x ticks and labels
+      var mch = oldChild
+      let xTicks = child.xticks(isSecondary = true)
+      let xLabel = child.xlabel("X label sec", isSecondary = true)
+      mch.addObj concat(xticks, @[xlabel])
+      child.addObj concat(xticks, @[xlabel])
+      for ch in mch.objects:
+        case ch.kind:
+        of goTick:
+          check ch.tkAxis == akX
+          check ch.tkPos.y == XAxisYPos(isSecondary = true)
+          check ch.tkSecondary == true
+        of goLabel:
+          check ch.txtText == "X label sec"
+          check ch.txtPos.y.pos.round.int == -43
+        else: check false
+    block:
+      # x ticks and labels
+      var mch = oldChild
+      let yTicks = child.yticks(isSecondary =  true)
+      let yLabel = child.ylabel("Y label sec", isSecondary = true)
+      mch.addObj concat(yticks, @[ylabel])
+      child.addObj concat(yticks, @[ylabel])
+      for ch in mch.objects:
+        case ch.kind:
+        of goTick:
+          check ch.tkAxis == akY
+          check ch.tkPos.x == YAxisXPos(isSecondary = true)
+          check ch.tkSecondary == true
+        of goLabel:
+          check ch.txtText == "Y label sec"
+          check ch.txtPos.x.pos.round.int == 523
+        else: check false
+    view.children.add child
+    view.draw("testAxes.pdf")

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -84,6 +84,7 @@ suite "Embeddings":
   test "Dummy":
     # TODO: have to write a lot more test, which test coordinatees under embeddings!
     # As far as I'm aware there are still some bugs lurking here :/
+    discard
 
 suite "Viewport":
   test "Mutable children":


### PR DESCRIPTION
This PR adds CI via travis. 

Also support for secondary axes via `isSecondary` parameters to the `tick`, `label` and `tickLabel` procs (in detail see the commits). The only difference is the position of the X (Y) position for the Y (X) axes, the direction the margin is applied and the direction of the ticks.

Also the filetype is now deduced from the filename. Supported filetypes:
- pdf
- svg
- png

More may be added later.
