### PR TITLE
marker field in Style object, fix `zip` regression, v0.1.4

### DIFF
--- a/ginger.nimble
+++ b/ginger.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.3"
+version       = "0.1.4"
 author        = "Vindaar"
 description   = "A Grid (R) like package in Nim"
 license       = "MIT"

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -2555,7 +2555,10 @@ proc draw(img: BImage, view: Viewport) =
     #mchView.hImg = quant(view.hImg.val * mchView.height.toRelative(view.wImg).val, ukPoint)
     doAssert mchView.wImg == view.wImg
     doAssert mchView.hImg == view.hImg
-    mchView.rotate = view.rotate
+    if view.rotate.isSome and mchView.rotate.isNone:
+      # only propagate if rotation of parent is set but child has no
+      # rotation itself
+      mchView.rotate = view.rotate
     img.draw(mchView)
 
 proc parseFilename(fname: string): FiletypeKind =

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -52,9 +52,6 @@ type
     goPolyLine, # a line connecting several points
     goComposite # an object consisting of several other GraphObjects
 
-  MarkerKind* = enum
-    mkCircle, mkCross, mkRotCross, mkStar
-
   CompositeKind* = enum
     cmpErrorBar # an error bar consisting of potentially several lines
 

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -1753,21 +1753,23 @@ proc initTickLabel(view: Viewport,
   case tick.tkAxis
   of akX:
     alignTo = taCenter
-    let scale = loc.x.scale
-    let xCoord = Coord1D(pos: loc.x.pos, kind: ukData,
-                         scale: scale, axis: akX)
-    # TODO: if we don't convert to relative here, the result (while being 1.0 effectively)
-    # will not line up with the correct location! Problem with embedding?
-    let yCoord = XAxisYPos(isSecondary = isSecondary) # Coord1D(pos: 1.0, kind: ukRelative) #loc.y.scale.low, kind: ukData,
-    #scale: loc.y.scale, axis: akY)
-    origin = Coord(x: xCoord,
-                   y: yCoord + yLabelOriginOffset(isSecondary))
-    if labelTxt.isNone:
-      # NOTE: for the `tickScale` required for `formatTickValue` we will use the `scale` attached
-      # to the tick position `/ 10.0`. (`10` from the default number of ticks). Since we divide
-      # by 10.0 in `formatTickValue` and users won't be using 1 or 100 ticks, we expect to be able
-      # to detect zero values.
-      text = &"{formatTickValue(loc.x.pos, (scale.high - scale.low) / 10.0)}"
+    let yCoord = XAxisYPos(isSecondary = isSecondary)
+    case loc.x.kind
+    of ukData:
+      let scale = loc.x.scale
+      origin = Coord(x: loc.x,
+                     y: yCoord + yLabelOriginOffset(isSecondary))
+      if labelTxt.isNone:
+        # NOTE: for the `tickScale` required for `formatTickValue` we will use the `scale` attached
+        # to the tick position `/ 10.0`. (`10` from the default number of ticks). Since we divide
+        # by 10.0 in `formatTickValue` and users won't be using 1 or 100 ticks, we expect to be able
+        # to detect zero values.
+        text = &"{formatTickValue(loc.x.pos, (scale.high - scale.low) / 10.0)}"
+    else:
+      doAssert labelTxt.isSome, "if tick contains `tkPos.kind != ukData` a label text " &
+        "must be provided!"
+      origin = Coord(x: loc.x,
+                     y: yCoord + yLabelOriginOffset(isSecondary))
     if gobjName == "tickLabel":
       gobjName = "x" & name
     result = view.initText(origin, text, textKind = goTickLabel,
@@ -1780,20 +1782,24 @@ proc initTickLabel(view: Viewport,
       alignTo = taRight
     else:
       alignTo = taLeft
-    let scale = loc.y.scale
-    # TODO: if we don't convert to relative here, the result (while being 0.0 effectively)
-    # will not line up with the correct location! Problem with embedding?
     let xCoord = YAxisXPos(isSecondary = isSecondary)
-    let yCoord = Coord1D(pos: loc.y.pos, kind: ukData,
-                         scale: scale, axis: akY)
-    origin = Coord(x: xCoord + xLabelOriginOffset(isSecondary),
-                   y: yCoord)
-    if labelTxt.isNone:
-      # NOTE: for the `tickScale` required for `formatTickValue` we will use the `scale` attached
-      # to the tick position `/ 10.0`. (`10` from the default number of ticks). Since we divide
-      # by 10.0 in `formatTickValue` and users won't be using 1 or 100 ticks, we expect to be able
-      # to detect zero values.
-      text = &"{formatTickValue(loc.y.pos, (scale.high - scale.low) / 10.0)}"
+    case loc.y.kind
+    of ukData:
+      let scale = loc.y.scale
+      origin = Coord(x: xCoord + xLabelOriginOffset(isSecondary),
+                     y: loc.y)
+      if labelTxt.isNone:
+        # NOTE: for the `tickScale` required for `formatTickValue` we will use the `scale` attached
+        # to the tick position `/ 10.0`. (`10` from the default number of ticks). Since we divide
+        # by 10.0 in `formatTickValue` and users won't be using 1 or 100 ticks, we expect to be able
+        # to detect zero values.
+        text = &"{formatTickValue(loc.y.pos, (scale.high - scale.low) / 10.0)}"
+    else:
+      doAssert labelTxt.isSome, "if tick contains `tkPos.kind != ukData` a label text " &
+        "must be provided!"
+      origin = Coord(x: xCoord,
+                     y: loc.y + yLabelOriginOffset(isSecondary))
+
     if gobjName == "tickLabel":
       gobjName = "y" & name
     result = view.initText(origin, text,

--- a/src/ginger/backends.nim
+++ b/src/ginger/backends.nim
@@ -4,7 +4,7 @@ import types
 
 export types
 export chroma
-export cairo
+#export cairo
 
 import backendCairo
 export backendCairo

--- a/src/ginger/macroUtils.nim
+++ b/src/ginger/macroUtils.nim
@@ -60,4 +60,3 @@ macro replace*(c: typed, x: untyped): untyped =
   for ch in x:
     cImpl = findReplace(cImpl, ch)
   result = cImpl
-  echo result.repr

--- a/src/ginger/types.nim
+++ b/src/ginger/types.nim
@@ -45,9 +45,13 @@ type
     slant*: FontSlant
     color*: Color
 
+  MarkerKind* = enum
+    mkCircle, mkCross, mkRotCross, mkStar
+
   Style* = object
     color*: Color
     size*: float
     lineType*: LineType
     lineWidth*: float
     fillColor*: Color
+    marker*: MarkerKind

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -123,7 +123,7 @@ suite "Viewport":
                              xScale = some(xScale),
                              yScale = some(yScale))
     for p in points:
-      gobjPoints.add initPoint(view2, (x: p.a, y: p.b),
+      gobjPoints.add initPoint(view2, (x: p[0], y: p[0]),
                                marker = mkCross)
     view2.addObj gobjPoints
     for p in view2.objects:
@@ -154,7 +154,7 @@ suite "Viewport":
                              xScale = some(xScale),
                              yScale = some(yScale))
     for p in points:
-      gobjPoints.add initPoint(view2, (x: p.a, y: p.b),
+      gobjPoints.add initPoint(view2, (x: p[0], y: p[0]),
                                marker = mkCross)
     view2.addObj gobjPoints
     for p in view2.objects:
@@ -185,7 +185,7 @@ suite "Viewport":
                              xScale = some(xScale),
                              yScale = some(yScale))
     for p in points:
-      gobjPoints.add initPoint(view2, (x: p.a, y: p.b),
+      gobjPoints.add initPoint(view2, (x: p[0], y: p[0]),
                                marker = mkCross)
     view2.addObj gobjPoints
     for p in view2.objects:


### PR DESCRIPTION
For easier handling of styles in ggplotnim `Style` has now a marker field.

Also fixes a recent regression due to the change in Nim devel that `zip` now returns an anonymous tuple.

edit:

Added to the PR was the following two things:
- `initTickLabel` accepts `ukRelative` coordinates iff also a text label is given. This is used in ggplotnim to set ticks in the middle of a discrete viewport.
- fix a bug in the application of a viewports' rotation. Only apply it parent has `some` and child has `none`.