### PR TITLE
Allow rotation of tick labels (and axis labels)

### DIFF
--- a/ginger.nimble
+++ b/ginger.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.4"
+version       = "0.1.5"
 author        = "Vindaar"
 description   = "A Grid (R) like package in Nim"
 license       = "MIT"

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -78,6 +78,7 @@ type
       txtFont*: Font
       txtPos*: Coord
       txtAlign*: TextAlignKind
+      # NOTE: do we need this really?
       txtRotate*: float # possible additional rotation
     of goGrid:
       gdOrigin: Coord     # Coordinate of origin of plot viewport

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -232,7 +232,34 @@ suite "Viewport":
         else: check false
 
     block:
-      # x ticks and labels
+      # rotated tick labels and labels, X axis
+      var mch = oldChild
+      let ticksLabs = block:
+                    var locsC: seq[Coord1D]
+                    let locs = linspace(0.1, 0.9, 5)
+                    for i in 0 ..< 5:
+                      locsC.add Coord1D(pos: locs[i], kind: ukRelative)
+                    (locsC, locs.mapIt($it))
+      let (tickObjs, labObjs) = child.tickLabels(ticksLabs[0], ticksLabs[1], akX, rotate = some(-45.0))
+      # rotating the label is probably not that useful most of the time
+      let xLabel = child.xlabel("X label", rotate = some(-30.0))
+      mch.addObj concat(tickObjs, labObjs, @[xlabel])
+      for ch in mch.objects:
+        case ch.kind:
+        of goTick:
+          check ch.tkAxis == akX
+          check ch.tkPos.y == XAxisYPos()
+        of goLabel:
+          check ch.txtText == "X label"
+          check ch.rotate.isSome
+          check ch.rotate.get == -30.0
+        of goTickLabel:
+          check ch.rotate.isSome
+          check ch.rotate.get == -45.0
+        else: check false
+
+    block:
+      # y ticks and labels
       var mch = oldChild
       let yTicks = child.yticks()
       let yLabel = child.ylabel("Y label")
@@ -247,8 +274,36 @@ suite "Viewport":
           check ch.txtText == "Y label"
           check ch.txtPos.x.pos.round.int == -43
         else: check false
+
     block:
-      # x ticks and labels
+      # rotated tick labels and labels, Y axis
+      var mch = oldChild
+      let ticksLabs = block:
+                    var locsC: seq[Coord1D]
+                    let locs = linspace(0.1, 0.9, 5)
+                    for i in 0 ..< 5:
+                      locsC.add Coord1D(pos: locs[i], kind: ukRelative)
+                    (locsC, locs.mapIt($it))
+      let (tickObjs, labObjs) = child.tickLabels(ticksLabs[0], ticksLabs[1], akY, rotate = some(-45.0))
+      # rotating the label is probably not that useful most of the time
+      let yLabel = child.xlabel("Y label", rotate = some(-30.0))
+      mch.addObj concat(tickObjs, labObjs, @[ylabel])
+      for ch in mch.objects:
+        case ch.kind:
+        of goTick:
+          check ch.tkAxis == akY
+          check ch.tkPos.x == YAxisXPos()
+        of goLabel:
+          check ch.txtText == "Y label"
+          check ch.rotate.isSome
+          check ch.rotate.get == -30.0
+        of goTickLabel:
+          check ch.rotate.isSome
+          check ch.rotate.get == -45.0
+        else: check false
+
+    block:
+      # x ticks and labels, secondary
       var mch = oldChild
       let xTicks = child.xticks(isSecondary = true)
       let xLabel = child.xlabel("X label sec", isSecondary = true)
@@ -265,7 +320,7 @@ suite "Viewport":
           check ch.txtPos.y.pos.round.int == -43
         else: check false
     block:
-      # x ticks and labels
+      # y ticks and labels
       var mch = oldChild
       let yTicks = child.yticks(isSecondary =  true)
       let yLabel = child.ylabel("Y label sec", isSecondary = true)

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -240,7 +240,8 @@ suite "Viewport":
                     for i in 0 ..< 5:
                       locsC.add Coord1D(pos: locs[i], kind: ukRelative)
                     (locsC, locs.mapIt($it))
-      let (tickObjs, labObjs) = child.tickLabels(ticksLabs[0], ticksLabs[1], akX, rotate = some(-45.0))
+      let (tickObjs, labObjs) = child.tickLabels(ticksLabs[0], ticksLabs[1], akX, rotate = some(-45.0),
+                                                 alignToOverride = some(taRight))
       # rotating the label is probably not that useful most of the time
       let xLabel = child.xlabel("X label", rotate = some(-30.0))
       mch.addObj concat(tickObjs, labObjs, @[xlabel])
@@ -256,6 +257,7 @@ suite "Viewport":
         of goTickLabel:
           check ch.rotate.isSome
           check ch.rotate.get == -45.0
+          check ch.txtAlign == taRight
         else: check false
 
     block:
@@ -284,7 +286,8 @@ suite "Viewport":
                     for i in 0 ..< 5:
                       locsC.add Coord1D(pos: locs[i], kind: ukRelative)
                     (locsC, locs.mapIt($it))
-      let (tickObjs, labObjs) = child.tickLabels(ticksLabs[0], ticksLabs[1], akY, rotate = some(-45.0))
+      let (tickObjs, labObjs) = child.tickLabels(ticksLabs[0], ticksLabs[1], akY, rotate = some(-45.0),
+                                                 alignToOverride = some(taRight))
       # rotating the label is probably not that useful most of the time
       let yLabel = child.xlabel("Y label", rotate = some(-30.0))
       mch.addObj concat(tickObjs, labObjs, @[ylabel])
@@ -300,6 +303,7 @@ suite "Viewport":
         of goTickLabel:
           check ch.rotate.isSome
           check ch.rotate.get == -45.0
+          check ch.txtAlign == taRight
         else: check false
 
     block:


### PR DESCRIPTION
This finally exposes the option to rotate labels. For discrete plots in ggplotnim this is very useful, if many categories are shown next to one another.

Also allows to change the text alignment of the tick labels to e.g. right align rotated x tick labels.

Finally allows to rotate the x and y labels (although I'm not sure what use case that might have?).

