### PR TITLE
add a dummy backend to compile w/o depending on cairo: -d:noCairo

### DIFF
--- a/src/ginger/backendDummy.nim
+++ b/src/ginger/backendDummy.nim
@@ -1,0 +1,41 @@
+import chroma
+import math
+import types
+import options
+
+proc drawLine*(img: BImage, start, stop: Point,
+               style: Style,
+               rotateAngle: Option[(float, Point)] = none[(float, Point)]()) =
+  debugecho "WARNING: `drawLine` of dummy backend is being called!"
+
+proc drawPolyLine*(img: BImage, points: seq[Point],
+                   style: Style,
+                   rotateAngle: Option[(float, Point)] = none[(float, Point)]()) =
+  debugecho "WARNING: `drawPolyLine` of dummy backend is being called!"
+
+proc drawCircle*(img: BImage, center: Point, radius: float,
+                 lineWidth: float,
+                 strokeColor = color(0.0, 0.0, 0.0),
+                 fillColor = color(0.0, 0.0, 0.0, 0.0),
+                 rotateAngle: Option[(float, Point)] = none[(float, Point)]()) =
+  debugecho "WARNING: `drawCircle` of dummy backend is being called!"
+
+proc getTextExtent*(text: string, font: Font): TextExtent =
+  debugecho "WARNING: `getTextExtent` of dummy backend is being called!"
+
+proc drawText*(img: BImage, text: string, font: Font, at: Point,
+               alignKind: TextAlignKind = taLeft,
+               rotate: Option[float] = none[float](),
+               rotateInView: Option[(float, Point)] = none[(float, Point)]()) =
+  debugecho "WARNING: `drawText` of dummy backend is being called!"
+
+proc drawRectangle*(img: BImage, left, bottom, width, height: float,
+                    style: Style,
+                    rotateAngle: Option[(float, Point),] = none[(float, Point)]()) =
+  debugecho "WARNING: `drawRectangle` of dummy backend is being called!"
+
+proc initBImage*(filename: string,
+                 width, height: int,
+                 backend: BackendKind,
+                 fType: FiletypeKind): BImage =
+  debugecho "WARNING: `initBImage` of dummy backend is being called!"

--- a/src/ginger/backends.nim
+++ b/src/ginger/backends.nim
@@ -1,26 +1,32 @@
-import cairo
 import chroma
 import types
 
 export types
 export chroma
-#export cairo
 
-import backendCairo
-export backendCairo
 
-proc destroy*(img: var BImage) =
-  case img.backend
-  of bkCairo:
-    case img.fType
-    of fkPng:
-      let err = img.cCanvas.write_to_png(img.fname)
-      echo err, " output of write_to_png"
-    else: discard # not needed for SVG, PDF
-    img.cCanvas.destroy()
-  of bkVega:
-    discard
+when not defined(noCairo):
+  import cairo
+  import backendCairo
+  export backendCairo
 
+  proc destroy*(img: var BImage) =
+    case img.backend
+    of bkCairo:
+      case img.fType
+      of fkPng:
+        let err = img.cCanvas.write_to_png(img.fname)
+        echo err, " output of write_to_png"
+      else: discard # not needed for SVG, PDF
+      img.cCanvas.destroy()
+    of bkVega:
+      discard
+else:
+  proc destroy*(img: var BImage) =
+    echo "Nothing to destroy when compiled without backend."
+
+  import backendDummy
+  export backendDummy
 
 when isMainModule:
   # backend layer cairo code

--- a/src/ginger/types.nim
+++ b/src/ginger/types.nim
@@ -1,5 +1,20 @@
-import cairo
 import chroma
+
+when not defined(noCairo):
+  import cairo
+else:
+  type
+    TSurface = object
+      discard
+    PSurface = ptr TSurface
+
+    TTextExtents = object
+      x_bearing*: float64
+      y_bearing*: float64
+      width*: float64
+      height*: float64
+      x_advance*: float64
+      y_advance*: float64
 
 type
   BackendKind* = enum


### PR DESCRIPTION
This (at the moment anyways since we have no other backend) means that
in the compilation mode with `-d:noCairo` no output files will be created!

The reason for this implementation is to make (most) `ggplotnim` tests work on Azure with the Windows target (for the important libraries nim repo test) where we do not have access to cairo.

The nice thing is the dummy backend highlights how little work is actually required to add an additional backend for ginger. :)