### PR TITLE
add support to print text with line breaks

### DIFF
--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -937,6 +937,18 @@ proc height*(view: Viewport): Quantity =
   ## ukRelative!
   result = view.height.toRelative(length = some(view.hView))
 
+proc pointWidth*(view: Viewport): Quantity =
+  ## returns the width of the given viewport in absolute points
+  doAssert view.wView.unit == ukPoint
+  doAssert view.width.unit == ukRelative
+  result = quant(view.wView.val * view.width.val, unit = ukPoint)
+
+proc pointHeight*(view: Viewport): Quantity =
+  ## returns the height of the given viewport in absolute points
+  doAssert view.hView.unit == ukPoint
+  doAssert view.height.unit == ukRelative
+  result = quant(view.hView.val * view.height.val, unit = ukPoint)
+
 func updateScale(view: Viewport, c: var Coord1D) =
   ## update the scale coordinate of the 1D coordinate `c` in place
   if c.kind == ukData:

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -570,8 +570,9 @@ func toRelative*(p: Coord1D,
     if length.isSome:
       result = Coord1D(pos: (p.pos * relevantDim) / length.unsafeGet.toPoints.val,
                        kind: ukRelative)
-    raise newException(Exception,
-                       "Conversion from StrWidth to relative requires a length scale!")
+    else:
+      raise newException(Exception,
+                         "Conversion from StrWidth to relative requires a length scale!")
 
 func toPoints*(p: Coord1D,
                length: Option[Quantity] = none[Quantity]()): Coord1D =

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -564,7 +564,8 @@ func toRelative*(p: Coord1D,
     # given font, or assuming a font size in dots calculate from DPI?
     # Do the former for now
     let extents = getTextExtent(p.text, p.font)
-    let relevantDim = if p.kind == ukStrWidth: extents.width else: extents.height
+    let relevantDim = if p.kind == ukStrWidth: extents.x_bearing + extents.x_advance
+                      else: extents.y_advance - extents.y_bearing
     # TODO: assume we can only use `width` here. Maybe have to consider bearing too!
     if length.isSome:
       result = Coord1D(pos: (p.pos * relevantDim) / length.unsafeGet.toPoints.val,
@@ -609,7 +610,8 @@ func toPoints*(p: Coord1D,
     # Do the former for now
     let extents = getTextExtent(p.text, p.font)
     # TODO: assume we can only use `width` here. Maybe have to consider bearing too!
-    let relevantDim = if p.kind == ukStrWidth: extents.width else: extents.height
+    let relevantDim = if p.kind == ukStrWidth: extents.x_bearing + extents.x_advance
+                      else: extents.y_advance - extents.y_bearing#extents.height
     result = Coord1D(pos: p.pos * relevantDim,
                      kind: ukPoint)
 

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -89,7 +89,7 @@ suite "Coordinate transformations":
     let c2 = Coord1D(pos: 0.3, kind: ukCentimeter)
     let c3 = c1 + c2
     check c3.kind == ukPoint
-    check abs(c3.pos - 79.5358267) < 1e-4
+    check abs(c3.pos - 77.5358267) < 1e-4
 
 suite "Embeddings":
   test "Dummy":


### PR DESCRIPTION
`initMultiLineText` automatically performs the spacing of individual lines. This makes it easy to print multiple lines in correct alignment.