### PR TITLE
Improve arithmetic, add gradients, improve nesting / embeddings

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,0 +1,35 @@
+* v0.1.15
+- fix =pointWidth= and =pointHeight= to return real width and height
+  of viewport
+- add arithmetic procs for =Quantity=.
+  These respect absolute units and try to remain them. If both are
+  absolute, result is absolute. If only one is absolute the result
+  will also be absolute. Only relative returned if both are relative.
+- fix arithmetic for =Coord1D= to effectively follow the same rules as
+  the ones for =Quantity= mentioned above
+- fixes many wrong scales used for conversions / embeddings
+  -> This and the above means adding an absolute distance to some
+  quantity or coordinate will now result in that distance on the final
+  plot, no matter how embedded the current viewport is!
+- add =drawBoundary= proc to highlight different viewports (including
+  writing its name / a number into the center with different colors)
+- =initLine= is now public
+- tick label related procs now allow custom margin to be set (by
+  default it's 0.4 cm for y labels / ticks and 0.5 cm for x labels / ticks)
+- tick calculations now fully respect =boundScale= if given (that is
+  the resulting's objects (and view's) data scale is =boundScale=
+  instead of the new scale
+- =layout= is significantly improved. It allows absolute units and
+  does not convert these to relative. However, margins are not allowed
+  (have no effect) at the moment. But they were broken.
+- add support for gradients. So far only on rectangles, but that's an
+  easy fix.
+
+
+
+
+
+
+
+
+

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -1686,6 +1686,39 @@ proc initText*(view: Viewport,
     result.rotate = some(rotate.get())
   setFontOrDefault(result, font)
 
+proc drawBoundary*(view: var Viewport,
+                   color = none[Color](),
+                   writeName = false,
+                   writeNumber = none[int](),
+                   style = none[Style]()) =
+  ## Adds a boundary (a rectangle) around the given viewport
+  var mstyle: Option[Style]
+  if style.isNone:
+    let c = if color.isSome: color.unsafeGet else: black
+    mstyle = some(Style(lineWidth: 1.0,
+                        color: c,
+                        fillColor: transparent,
+                        lineType: ltSolid))
+  else: mstyle = style
+  let rect = view.initRect(left = 0.0, bottom = 0.0,
+                           width = 1.0, height = 1.0,
+                           style = mstyle)
+  view.addObj rect
+  if writeName:
+    # write name of layout in center
+    let text = view.initText(c(0.5, 0.5),
+                             text = view.name,
+                             textKind = goText,
+                             alignKind = taCenter)
+    view.addObj text
+  if writeNumber.isSome:
+    # write name of layout in center
+    let text = view.initText(c(0.5, 0.5),
+                             text = $writeNumber.unsafeGet,
+                             textKind = goText,
+                             alignKind = taCenter)
+    view.addObj text
+
 proc strHeight*(val: float, font: Font): Coord1D =
   ## returns a Coord1D of kind `ukStrHeight` for the given
   ## number of times the string height `val` for font `font`.

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -1081,13 +1081,10 @@ proc to*(p: Coord1D, toKind: UnitKind,
     case toKind
     of ukRelative: result = p # nothing to do
     of ukPoint:
-      # echo "Performing conversion to ", ukPoint
-      # echo "For pos ", pRel, " with length ", absLength.get()
       doAssert absLength.isSome, "Conversion to absolute requires a length scale!"
       result = Coord1D(pos: pRel.pos * absLength.get().toPoints.val,
                        length: some(absLength.get.toPoints),
                        kind: ukPoint)
-      # echo "Result is ", result
     of ukInch:
       doAssert absLength.isSome, "Conversion to inches requires an absolute length scale!"
       # assumes absLength is size in points!
@@ -1374,17 +1371,6 @@ proc convertToKind(c: Coord1D, toKind: Coord1D): Coord1D =
   else:
     raise newException(Exception, "convertToKind not implemented for " & $toKind.kind)
 
-#proc translate(c: Coord1D, byCoord: Coord1D): Coord1D =
-#  ## translates the coordinate `c` by `byCoord`
-#  let pos = c.toRelative.pos + byCoord.toRelative.pos
-#  result = Coord1D(pos: pos, kind: ukRelative)
-#  result = result.convertToKind(c)
-
-#proc translate(c: Coord, byCoord: Coord): Coord =
-#  result = Coord(x: c.x.translate(byCoord.x),
-#                 y: c.y.translate(byCoord.y),
-#                 kind: c.kind)
-
 proc embedInto*(q: Quantity, axKind: AxisKind, view: Viewport): Quantity =
   ## Embeds the quantity `q` into the viewport `view`
   ## NOTE: Embedding a quantity is a special case. A quantity (in our case)
@@ -1427,13 +1413,10 @@ proc embedInto(c: Coord1D, axKind: AxisKind, view: Viewport): Coord1D =
   of akX:
     case c.kind
     of ukPoint, ukCentimeter, ukInch:
-      # echo "Pos is ", c, " and origin ", view.origin.x
       let origAbs = view.origin.x.to(ukPoint, absLength = some(view.wImg))
-      # echo "Orig abs ", origAbs
       # NOTE: for a Coord1D giving a *value* the following is a scaling, but for
       # a Coord1D giving a *coordinate* it is a translation!
-      pos = origAbs + c #* view.width
-      # echo "Pos now is ", pos
+      pos = origAbs + c
     else:
       pos = Coord1D(pos: left(view).pos + width(view).val * c.toRelative.pos,
                     kind: ukRelative)
@@ -1441,12 +1424,8 @@ proc embedInto(c: Coord1D, axKind: AxisKind, view: Viewport): Coord1D =
   of akY:
     case c.kind
     of ukPoint, ukCentimeter, ukInch:
-      # echo "View is ", view.wImg
       let origAbs = view.origin.y.to(ukPoint, absLength = some(view.hImg))
-      #pos = view.origin.y + c# * view.height
-      #var mc = c
-      #mc.length = some(view.hImg)
-      pos = origAbs + c #* view.height
+      pos = origAbs + c
     else:
       pos = Coord1D(pos: bottom(view).pos + height(view).val * c.toRelative.pos,
                     kind: ukRelative)
@@ -1458,23 +1437,6 @@ proc embedInto(c: Coord, view: Viewport): Coord =
     cX = c.x.embedInto(akX, view)
     cY = c.y.embedInto(akY, view)
   result = Coord(x: cX, y: cY)
-  #var
-  #  posX: Coord1D
-  #  posY: Coord1D
-  #case c.x.kind
-  #of ukPoint, ukCentimeter, ukInch:
-  #  posX = view.origin.x + c.x
-  #else:
-  #  posX = Coord1D(pos: left(view) + width(view) * c.x.toRelative.pos,
-  #                 kind: ukRelative)
-  #case c.y.kind
-  #of ukPoint, ukCentimeter, ukInch:
-  #  posY = view.origin.y + c.y
-  #else:
-  #  posY = Coord1D(pos: bottom(view) + height(view) * c.y.toRelative.pos,
-  #                 kind: ukRelative)
-  #result = Coord(x: posX, y: posY, kind: ukRelative)
-
 
 proc embedInto(view: Viewport, into: Viewport): Viewport =
   ## embeds the given `view` into the `into` Viewport by embedding
@@ -1493,12 +1455,7 @@ proc embedInto(view: Viewport, into: Viewport): Viewport =
 proc point(c: Coord): Point =
   ## converts the given coordinate to `ukRelative` and returns the position as a
   ## `Point`
-  #result = (x: c.x.toRelative.pos, y: c.y.toRelative.pos)
   result = (x: c.x.pos, y: c.y.pos)
-
-
-
-
 
 ################################################################################
 ############ INIT FUNCTIONS

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -190,6 +190,9 @@ type
 
 const DPI = 72.27
 
+proc pointWidth*(view: Viewport): Quantity
+proc pointHeight*(view: Viewport): Quantity
+
 template defaultFont(pts = 12.0): untyped = Font(family: "sans-serif", size: pts, color: color(0.0, 0.0, 0.0))
 
 template setFontOrDefault(setTo, fontArg: untyped): untyped =

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -309,8 +309,7 @@ template absToInch(x: float): float = x / DPI
 template inchToCm(x: float): float = x * 2.54
 
 func toPoints*(q: Quantity,
-               length: Option[Quantity] = none[Quantity]()): Quantity {.raises: [ValueError,
-                                                                                 UnpackError].}  =
+               length: Option[Quantity] = none[Quantity]()): Quantity =
   ## returns the quantity converted to Points. This will fail if attempted to
   ## convert a non absolute unit!
   case q.unit
@@ -329,7 +328,7 @@ func toPoints*(q: Quantity,
     raise newException(ValueError, "Cannot convert quantity with unit " &
       $q.unit & " to points!")
 
-func toInch*(q: Quantity): Quantity {.raises: ValueError.}  =
+func toInch*(q: Quantity): Quantity =
   ## returns the quantity converted to inch. This will fail if attempted to
   ## convert a non absolute unit!
   case q.unit
@@ -340,7 +339,7 @@ func toInch*(q: Quantity): Quantity {.raises: ValueError.}  =
     raise newException(ValueError, "Cannot convert quantity with unit " &
       $q.unit & " to inch!")
 
-func toCentimeter*(q: Quantity): Quantity {.raises: ValueError.} =
+func toCentimeter*(q: Quantity): Quantity =
   ## returns the quantity converted to centimeter. This will fail if attempted to
   ## convert a non absolute unit!
   case q.unit
@@ -573,7 +572,7 @@ func initCoord1D*(at: float, kind: UnitKind = ukRelative): Coord1D =
 template c1*(at: float, kind: UnitKind = ukRelative): Coord1D =
   initCoord1D(at, kind)
 
-func initCoord1d*(view: Viewport, at: float,
+proc initCoord1d*(view: Viewport, at: float,
                   axKind: AxisKind,
                   kind: UnitKind = ukPoint): Coord1D =
   ## Full name should be `initCoord1D`, but since it's a convenience function
@@ -611,7 +610,7 @@ template c1*(view: Viewport, at: float,
              kind: UnitKind = ukPoint): Coord1D =
   initCoord1D(view, at, axKind, kind)
 
-func initCoord*(x, y: float, kind: UnitKind = ukRelative): Coord =
+proc initCoord*(x, y: float, kind: UnitKind = ukRelative): Coord =
   ## returns a coordinate at coordinates x, y of kind `kind`
   result = Coord(x: initCoord1D(x, kind = kind),
                  y: initCoord1D(y, kind = kind))
@@ -619,7 +618,7 @@ func initCoord*(x, y: float, kind: UnitKind = ukRelative): Coord =
 template c*(x, y: float, kind: UnitKind = ukRelative): Coord =
   initCoord(x, y, kind)
 
-func initCoord*(view: Viewport, x, y: float,
+proc initCoord*(view: Viewport, x, y: float,
                 kind: UnitKind = ukRelative): Coord =
   ## length and scale aware (using Viewport) initCoord, that automatically
   ## assigns the correct length and scale for absolute / data coords

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -883,8 +883,34 @@ proc `+`*(c1, c2: Coord1D): Coord1D =
       result = c1
       result.pos = c1.pos + c2.pos
   else:
-    result = Coord1D(pos: c1.toRelative.pos + c2.toRelative.pos,
-                     kind: ukRelative)
+    if c1.kind in {ukPoint, ukInch, ukCentimeter}:
+      result = c1
+      # convert to quantities and perform math on those
+      let scale = if c2.kind == ukData: some(c2.scale) else: none[Scale]()
+      let res = add(quant(c1.pos, c1.kind),
+                    quant(c2.pos, c2.kind),
+                    length = c1.length,
+                    scale = scale)
+      if res.unit == ukRelative:
+        result = c1(res.val, ukRelative)
+      else:
+        result.pos = res.val
+    elif c2.kind in {ukPoint, ukInch, ukCentimeter}:
+      # convert to quantities and perform math on those
+      result = c2
+      # convert to quantities and perform math on those
+      let scale = if c1.kind == ukData: some(c1.scale) else: none[Scale]()
+      let res = add(quant(c1.pos, c1.kind),
+                    quant(c2.pos, c2.kind),
+                    length = c2.length,
+                    scale = scale)
+      if res.unit == ukRelative:
+        result = c1(res.val, ukRelative)
+      else:
+        result.pos = res.val
+    else:
+      result = Coord1D(pos: c1.toRelative.pos + c2.toRelative.pos,
+                       kind: ukRelative)
 
 proc `-`*(c1, c2: Coord1D): Coord1D =
   ## subtracts two Coord1D by converting to relative coordinates if necessary.
@@ -901,8 +927,33 @@ proc `-`*(c1, c2: Coord1D): Coord1D =
     else:
       result.pos = c1.pos - c2.pos
   else:
-    result = Coord1D(pos: c1.toRelative.pos - c2.toRelative.pos,
-                     kind: ukRelative)
+    if c1.kind in {ukPoint, ukInch, ukCentimeter}:
+      result = c1
+      # convert to quantities and perform math on those
+      let scale = if c2.kind == ukData: some(c2.scale) else: none[Scale]()
+      let res = sub(quant(c1.pos, c1.kind),
+                    quant(c2.pos, c2.kind),
+                    length = c1.length,
+                    scale = scale)
+      if res.unit == ukRelative:
+        result = c1(res.val, ukRelative)
+      else:
+        result.pos = res.val
+    elif c2.kind in {ukPoint, ukInch, ukCentimeter}:
+      result = c2
+      # convert to quantities and perform math on those
+      let scale = if c1.kind == ukData: some(c1.scale) else: none[Scale]()
+      let res = sub(quant(c1.pos, c1.kind),
+                       quant(c2.pos, c2.kind),
+                       length = c2.length,
+                       scale = scale)
+      if res.unit == ukRelative:
+        result = c1(res.val, ukRelative)
+      else:
+        result.pos = res.val
+    else:
+      result = Coord1D(pos: c1.toRelative.pos - c2.toRelative.pos,
+                       kind: ukRelative)
 
 proc `*`*(c1, c2: Coord1D): Coord1D =
   ## subtracts two Coord1D by converting to relative coordinates if necessary.
@@ -921,8 +972,33 @@ proc `*`*(c1, c2: Coord1D): Coord1D =
     else:
       result.pos = c1.pos * c2.pos
   else:
-    result = Coord1D(pos: c1.toRelative.pos * c2.toRelative.pos,
-                     kind: ukRelative)
+    if c1.kind in {ukPoint, ukInch, ukCentimeter}:
+      result = c1
+      # convert to quantities and perform math on those
+      let scale = if c2.kind == ukData: some(c2.scale) else: none[Scale]()
+      let res = times(quant(c1.pos, c1.kind),
+                      quant(c2.pos, c2.kind),
+                      length = c1.length,
+                      scale = scale)
+      if res.unit == ukRelative:
+        result = c1(res.val, ukRelative)
+      else:
+        result.pos = res.val
+    elif c2.kind in {ukPoint, ukInch, ukCentimeter}:
+      result = c2
+      # convert to quantities and perform math on those
+      let scale = if c1.kind == ukData: some(c1.scale) else: none[Scale]()
+      let res = times(quant(c1.pos, c1.kind),
+                      quant(c2.pos, c2.kind),
+                      length = c2.length,
+                      scale = scale)
+      if res.unit == ukRelative:
+        result = c1(res.val, ukRelative)
+      else:
+        result.pos = res.val
+    else:
+      result = Coord1D(pos: c1.toRelative.pos * c2.toRelative.pos,
+                       kind: ukRelative)
 
 proc `/`*(c1, c2: Coord1D): Coord1D =
   ## divides two Coord1D by converting to relative coordinates.
@@ -939,9 +1015,33 @@ proc `/`*(c1, c2: Coord1D): Coord1D =
     else:
       result.pos = c1.pos / c2.pos
   else:
-    result = Coord1D(pos: c1.toRelative.pos / c2.toRelative.pos,
-                     kind: ukRelative)
-
+    if c1.kind in {ukPoint, ukInch, ukCentimeter}:
+      result = c1
+      # convert to quantities and perform math on those
+      let scale = if c2.kind == ukData: some(c2.scale) else: none[Scale]()
+      let res = divide(quant(c1.pos, c1.kind),
+                       quant(c2.pos, c2.kind),
+                       length = c1.length,
+                       scale = scale)
+      if res.unit == ukRelative:
+        result = c1(res.val, ukRelative)
+      else:
+        result.pos = res.val
+    elif c2.kind in {ukPoint, ukInch, ukCentimeter}:
+      result = c2
+      # convert to quantities and perform math on those
+      let scale = if c1.kind == ukData: some(c1.scale) else: none[Scale]()
+      let res = divide(quant(c1.pos, c1.kind),
+                       quant(c2.pos, c2.kind),
+                       length = c2.length,
+                       scale = scale)
+      if res.unit == ukRelative:
+        result = c1(res.val, ukRelative)
+      else:
+        result.pos = res.val
+    else:
+      result = Coord1D(pos: c1.toRelative.pos / c2.toRelative.pos,
+                       kind: ukRelative)
 
 proc to*(p: Coord1D, toKind: UnitKind,
          absLength = none[Quantity](),

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -1632,13 +1632,16 @@ proc initRect*(view: Viewport,
                origin: Coord,
                width, height: Quantity,
                color = color(0.0, 0.0, 0.0),
+               gradient = none[Gradient](),
                style = none[Style](),
+               rotate = none[float](),
                name = "rect"): GraphObject =
   result = GraphObject(kind: goRect,
                        name: name,
                        reOrigin: origin.patchCoord(view),
-                       reWidth: width,#.patchCoord(view.wImg),
-                       reHeight: height)#.patchCoord(view.hImg))
+                       reWidth: width,
+                       reHeight: height,
+                       rotate: rotate)
   if style.isSome:
     result.style = style
   else:
@@ -1646,11 +1649,13 @@ proc initRect*(view: Viewport,
                               color: color(0.0, 0.0, 0.0, 0.0),
                               size: 0.0,
                               lineType: ltSolid,
-                              fillColor: color))
+                              fillColor: color,
+                              gradient: gradient))
 
 proc initRect*(view: Viewport,
                left, bottom, width, height: float,
                color = color(0.0, 0.0, 0.0),
+               gradient = none[Gradient](),
                style = none[Style](),
                name = "rect"): GraphObject =
   let origin = Coord(x: Coord1D(pos: left, kind: ukRelative),
@@ -1663,6 +1668,7 @@ proc initRect*(view: Viewport,
                          height = heightCoord,
                          color = color,
                          style = style,
+                         gradient = gradient,
                          name = name)
 
 proc initText*(view: Viewport,
@@ -1960,7 +1966,6 @@ proc initErrorBar*(view: Viewport,
                   x2 = pt.x,
                   y1 = errorUp,
                   y2 = errorDown)
-
       let chUp = view.initLine(
         start = Coord(x: pt.x - view.c1(locStyle.size, akX, ukPoint),
                       y: errorUp),
@@ -2780,7 +2785,8 @@ proc drawRect(img: BImage, gobj: GraphObject) =
                     gobj.reWidth.val, gobj.reHeight.val,
                     gobj.style.get, # if we end up here without a style,
                                     # it's a bug!
-                    gobj.rotateInView)
+                    rotate = gobj.rotate,
+                    rotateInView = gobj.rotateInView)
 
 proc drawPoint(img: BImage, gobj: GraphObject) =
   doAssert gobj.kind == goPoint, "object must be a `goPoint`!"

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -2506,13 +2506,15 @@ proc initTicks*(view: var Viewport,
       scale = view.yScale
 
     let (newScale, newWidth, newNumTicks) = calcTickLocations(scale, numTicks)
+    let tickScale = if boundScale.isSome: boundScale.unsafeGet
+                    else: newScale
     var autoTickLocs: seq[Coord]
     case axKind
     of akX:
       autoTickLocs = linspace(newScale.low, newScale.high, newNumTicks + 1).mapIt(
         axisCoord(Coord1D(pos: it,
                           kind: ukData,
-                          scale: newScale,
+                          scale: tickScale,
                           axis: akX),
                   akX,
                   isSecondary)
@@ -2521,7 +2523,7 @@ proc initTicks*(view: var Viewport,
       autoTickLocs = linspace(newScale.low, newScale.high, newNumTicks + 1).mapIt(
         axisCoord(Coord1D(pos: it,
                           kind: ukData,
-                          scale: newScale,
+                          scale: tickScale,
                           axis: akY),
                   akY,
                   isSecondary)
@@ -2535,9 +2537,9 @@ proc initTicks*(view: var Viewport,
     # finally update the scale associated to the view
     case axKind
     of akX:
-      view.xScale = newScale
+      view.xScale = tickScale
     of akY:
-      view.yScale = newScale
+      view.yScale = tickScale
 
     # and update the scales of all objects owned by the viewport
     if updateScale:

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -1804,11 +1804,11 @@ proc scaleTo(p: Point, view: Viewport): Point =
   ## scales the point from data coordinates to viewport coordinates
   discard
 
-proc initLine(view: Viewport,
-              start: Coord,
-              stop: Coord,
-              style: Option[Style] = none[Style](),
-              name = "line"): GraphObject =
+proc initLine*(view: Viewport,
+               start: Coord,
+               stop: Coord,
+               style: Option[Style] = none[Style](),
+               name = "line"): GraphObject =
   result = GraphObject(kind: goLine,
                        name: name,
                        lnStart: start,

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -2207,6 +2207,7 @@ proc initTickLabel(view: Viewport,
                    labelTxt: Option[string] = none[string](),
                    font: Option[Font] = none[Font](),
                    rotate = none[float](),
+                   margin = none[Coord1D](),
                    name = "tickLabel",
                    isSecondary = false,
                    alignToOverride = none[TextAlignKind]()): GraphObject =
@@ -2224,11 +2225,13 @@ proc initTickLabel(view: Viewport,
   case tick.tkAxis
   of akX:
     let yCoord = XAxisYPos(isSecondary = isSecondary)
+    let yOffset = if margin.isSome: margin.unsafeGet
+                  else: yLabelOriginOffset(isSecondary)
+    origin = Coord(x: loc.x,
+                   y: yCoord + yOffset)
     case loc.x.kind
     of ukData:
       let scale = loc.x.scale
-      origin = Coord(x: loc.x,
-                     y: yCoord + yLabelOriginOffset(isSecondary))
       if labelTxt.isNone:
         # NOTE: for the `tickScale` required for `formatTickValue` we will use the `scale` attached
         # to the tick position `/ 10.0`. (`10` from the default number of ticks). Since we divide
@@ -2238,8 +2241,6 @@ proc initTickLabel(view: Viewport,
     else:
       doAssert labelTxt.isSome, "if tick contains `tkPos.kind != ukData` a label text " &
         "must be provided!"
-      origin = Coord(x: loc.x,
-                     y: yCoord + yLabelOriginOffset(isSecondary))
     if gobjName == "tickLabel":
       gobjName = "x" & name
     result = view.initText(origin, text, textKind = goTickLabel,
@@ -2249,11 +2250,13 @@ proc initTickLabel(view: Viewport,
                            name = gobjName)
   of akY:
     let xCoord = YAxisXPos(isSecondary = isSecondary)
+    let xOffset = if margin.isSome: margin.unsafeGet
+                  else: xLabelOriginOffset(isSecondary)
+    origin = Coord(x: xCoord + xOffset,
+                   y: loc.y)
     case loc.y.kind
     of ukData:
       let scale = loc.y.scale
-      origin = Coord(x: xCoord + xLabelOriginOffset(isSecondary),
-                     y: loc.y)
       if labelTxt.isNone:
         # NOTE: for the `tickScale` required for `formatTickValue` we will use the `scale` attached
         # to the tick position `/ 10.0`. (`10` from the default number of ticks). Since we divide
@@ -2263,9 +2266,6 @@ proc initTickLabel(view: Viewport,
     else:
       doAssert labelTxt.isSome, "if tick contains `tkPos.kind != ukData` a label text " &
         "must be provided!"
-      origin = Coord(x: xCoord,
-                     y: loc.y + yLabelOriginOffset(isSecondary))
-
     if gobjName == "tickLabel":
       gobjName = "y" & name
     result = view.initText(origin, text,
@@ -2289,6 +2289,7 @@ proc axisCoord*(c: Coord1D, axKind: AxisKind,
 
 proc tickLabels*(view: Viewport, ticks: seq[GraphObject],
                  font: Option[Font] = none[Font](),
+                 margin = none[Coord1d](),
                  isSecondary = false,
                 ): seq[GraphObject] =
   ## returns all tick labels for the given ticks
@@ -2344,6 +2345,7 @@ proc tickLabels*(view: Viewport, ticks: seq[GraphObject],
       labelTxt = some(&"{formatTickValue(newPos[i], tickScale)}")
     result.add view.initTickLabel(tick = ticks[i], font = font,
                                   labelTxt = labelTxt,
+                                  margin = margin,
                                   isSecondary = isSecondary)
 
 proc initTick(view: Viewport,
@@ -2376,6 +2378,7 @@ proc tickLabels*(view: Viewport,
                  font: Option[Font] = none[Font](),
                  isSecondary = false,
                  rotate = none[float](),
+                 margin = none[Coord1D](),
                  alignToOverride = none[TextAlignKind]()
                 ): (seq[GraphObject], seq[GraphObject]) =
   ## Overload of `tickLabels`, which allows to define custom tick label
@@ -2395,6 +2398,7 @@ proc tickLabels*(view: Viewport,
                                       labelTxt = some(tickLabels[i]),
                                       isSecondary = isSecondary,
                                       rotate = rotate,
+                                      margin = margin,
                                       alignToOverride = alignToOverride)
 
 # taken straight from: *cough*

--- a/src/ginger/backendDummy.nim
+++ b/src/ginger/backendDummy.nim
@@ -31,7 +31,8 @@ proc drawText*(img: BImage, text: string, font: Font, at: Point,
 
 proc drawRectangle*(img: BImage, left, bottom, width, height: float,
                     style: Style,
-                    rotateAngle: Option[(float, Point),] = none[(float, Point)]()) =
+                    rotate: Option[float] = none[float](),
+                    rotateInView: Option[(float, Point),] = none[(float, Point)]()) =
   debugecho "WARNING: `drawRectangle` of dummy backend is being called!"
 
 proc initBImage*(filename: string,

--- a/src/ginger/types.nim
+++ b/src/ginger/types.nim
@@ -1,4 +1,5 @@
 import chroma
+import options
 
 when not defined(noCairo):
   import cairo
@@ -15,6 +16,10 @@ else:
       height*: float64
       x_advance*: float64
       y_advance*: float64
+
+    TPattern = object
+      discard
+    PPattern = ptr TPattern
 
 type
   BackendKind* = enum
@@ -67,6 +72,10 @@ type
   MarkerKind* = enum
     mkCircle, mkCross, mkRotCross, mkStar
 
+  Gradient* = object
+    colors*: seq[Color]
+    rotation*: float
+
   Style* = object
     color*: Color
     size*: float
@@ -75,3 +84,4 @@ type
     fillColor*: Color
     marker*: MarkerKind
     errorBarKind*: ErrorBarKind
+    gradient*: Option[Gradient] # overrides `color`

--- a/tests/tGradient.nim
+++ b/tests/tGradient.nim
@@ -1,0 +1,26 @@
+import ginger, sequtils, options
+import ggplotnim / colormaps / viridisRaw
+
+let viridis = ViridisRaw.mapIt(color(it[0], it[1], it[2]))
+
+var img = initViewport()
+var rect = img.initRect(#c(0.0, 0.0),
+                        c(0.5, 0.5),
+                        #width = quant(1.0, ukRelative),#ukCentimeter),
+                        #height = quant(1.0, ukRelative), #Centimeter),
+                        width = quant(11.0, ukCentimeter),
+                        height = quant(5.0, ukCentimeter),
+                        gradient = some(Gradient(colors: viridis)))
+echo rect
+let st = Style(color: color(0.0, 0.0, 1.0, 1.0),
+               lineType: ltSolid,
+               lineWidth: 1.0,
+               fillColor: grey92)
+var rect2 = rect
+rect2.rotate = some(30.0)
+
+img.background(some(st))
+img.addObj @[rect, rect2]
+
+#img.background()
+img.draw("tGradient.pdf")

--- a/tests/tNested.nim
+++ b/tests/tNested.nim
@@ -1,0 +1,56 @@
+
+import ginger
+
+var view = initViewport()
+view.layout(3, 3, colwidths = @[quant(2.5, ukCentimeter),
+                                quant(0.0, ukRelative),
+                                quant(5.0, ukCentimeter)],
+            rowheights = @[quant(1.25, ukCentimeter),
+                           quant(0.0, ukRelative),
+                           quant(2.0, ukCentimeter)])
+block:
+  var mv = view
+  let colors = ggColorHue(15)
+  var idx = 0
+  for ch in mitems(mv.children):
+    ch.drawBoundary(some(colors[idx]), writeNumber = some(idx))
+    inc idx
+
+  var lg = mv[5]
+  lg.layout(2, 2,
+            colWidths = @[quant(1.0, ukCentimeter), # for space to plot
+                          quant(0.0, ukRelative)], # for legend. incl header
+            rowHeights = @[quant(1.0, ukCentimeter), # for header
+                           quant(4.5, ukCentimeter)]) # for act. legend
+  for ch in mitems(lg.children):
+    ch.drawBoundary(some(colors[idx]), writeNumber = some(idx))
+    inc idx
+
+  var legView = lg[3]
+  legView.layout(3, 1, colWidths = @[quant(1.0, ukCentimeter),
+                                     quant(0.5, ukCentimeter),
+                                     quant(0.0, ukRelative)])
+  for ch in mitems(legView.children):
+    ch.drawBoundary(some(colors[idx]), writeNumber = some(idx))
+    inc idx
+  lg[3] = legView
+  mv[5] = lg
+  mv.draw("boundsCont.pdf")
+block:
+  let colors = ggColorHue(15)
+  var idx = 0
+  #for ch in mitems(view.children):
+  #  ch.drawBoundary(some(colors[idx]), writeNumber = some(idx))
+  #  inc idx
+
+  var lg = view[5]
+  lg.layout(2, 2,
+              colWidths = @[quant(1.0, ukCentimeter), # for space to plot
+                            quant(0.0, ukRelative)], # for legend. incl header
+              rowHeights = @[quant(1.0, ukCentimeter), # for header
+                             quant(0.0, ukRelative)]) # for act. legend
+  for ch in mitems(lg.children):
+    ch.drawBoundary(some(colors[idx]), writeNumber = some(idx))
+    inc idx
+  view[5] = lg
+  view.draw("boundsDiscr.pdf")


### PR DESCRIPTION
This PR brings many improvements, mainly related to performing calculations with quantities (now allowed) and coordinates.

During embeddings and calculations absolute values are now preferred. If an absolute value is part of a calculation / embedding, the result will also be absolute.

The full changelog:

- fix =pointWidth= and =pointHeight= to return real width and height
  of viewport
- add arithmetic procs for =Quantity=.
  These respect absolute units and try to remain them. If both are
  absolute, result is absolute. If only one is absolute the result
  will also be absolute. Only relative returned if both are relative.
- fix arithmetic for =Coord1D= to effectively follow the same rules as
  the ones for =Quantity= mentioned above
- fixes many wrong scales used for conversions / embeddings
  -> This and the above means adding an absolute distance to some
  quantity or coordinate will now result in that distance on the final
  plot, no matter how embedded the current viewport is!
- add =drawBoundary= proc to highlight different viewports (including
  writing its name / a number into the center with different colors)
- =initLine= is now public
- tick label related procs now allow custom margin to be set (by
  default it's 0.4 cm for y labels / ticks and 0.5 cm for x labels / ticks)
- tick calculations now fully respect =boundScale= if given (that is
  the resulting's objects (and view's) data scale is =boundScale=
  instead of the new scale
- =layout= is significantly improved. It allows absolute units and
  does not convert these to relative. However, margins are not allowed
  (have no effect) at the moment. But they were broken.
- add support for gradients. So far only on rectangles, but that's an
  easy fix.
