### PR TITLE
`font` field for Style, `ignoreOverflow` in `layout`

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,9 @@
+* v0.1.16
+- =layout= now has a =ignoreOverflow= argument, which if true will
+  allow overflowing layouts, i.e. layouts which exceed the size of the
+  viewport
+- =Style= now has a =font= field
+
 * v0.1.15
 - fix =pointWidth= and =pointHeight= to return real width and height
   of viewport

--- a/src/ginger/types.nim
+++ b/src/ginger/types.nim
@@ -85,3 +85,4 @@ type
     marker*: MarkerKind
     errorBarKind*: ErrorBarKind
     gradient*: Option[Gradient] # overrides `color`
+    font*: Font


### PR DESCRIPTION
`Style` now has a `font` field and `ignoreOverflow` allows to ignore overflowing layouts.

* v0.1.16
- =layout= now has a =ignoreOverflow= argument, which if true will
  allow overflowing layouts, i.e. layouts which exceed the size of the
  viewport
- =Style= now has a =font= fieldn