### PR TITLE
Viewport, GraphObject are ref, less cairo calls

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,22 @@
+* v0.1.18
+- fix remaining places, which are supposed to use =pointWidth/Height=
+- make =ignoreOverflow= work for =layout= (was previously ignored),
+  which allows for total heights / widhts larger than the
+  viewport. Better to have overflowing viewports than crash if
+  desired!
+- simplify =toAbsImage= implementation, calls =to= for each =Coord=
+  field instead now.
+- deprecate =to= for =Coord=. Use =to= for =Coord1D= instead on each
+  field!
+- =to= now return early if input already has output type
+- =BImage= now has a =PContext= field. Instead of creating a context
+  for each field, we now keep a global one, whose state we save and
+  revert. 
+- =Viewport= and =GraphObject= are now =ref objects= to avoid costly
+  copies, if we have large objects in =ggplotnim=. Reduces memory
+  footprint for plots with many elements significantly (1 Mio. point
+  scatter plot before 8.5 GB (!!!), now *cough* only 1.7 GB). 
+
 * v0.1.17
 Hotfix release for =v0.1.16= due to missing field.
 - add =alignKind= field to =Font=

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -190,8 +190,8 @@ type
 
 const DPI = 72.27
 
-proc pointWidth*(view: Viewport): Quantity
-proc pointHeight*(view: Viewport): Quantity
+proc pointWidth*(view: Viewport): Quantity {.inline.}
+proc pointHeight*(view: Viewport): Quantity {.inline.}
 
 template defaultFont(pts = 12.0): untyped = Font(family: "sans-serif", size: pts, color: color(0.0, 0.0, 0.0))
 
@@ -1235,15 +1235,15 @@ proc height*(view: Viewport): Quantity =
   ## ukRelative!
   result = view.height.toRelative(length = some(view.hImg))
 
-proc pointWidth*(view: Viewport): Quantity =
+proc pointWidth*(view: Viewport): Quantity {.inline.} =
   ## returns the width of the given viewport in absolute points
-  doAssert view.wView.unit == ukPoint
+  assert view.wView.unit == ukPoint
   result = times(view.wView, view.width.toRelative(length = some(view.wView)),
                  length = some(view.wView))
 
-proc pointHeight*(view: Viewport): Quantity =
+proc pointHeight*(view: Viewport): Quantity {.inline.} =
   ## returns the height of the given viewport in absolute points
-  doAssert view.hView.unit == ukPoint
+  assert view.hView.unit == ukPoint
   result = times(view.hView, view.height.toRelative(length = some(view.hView)),
                  length = some(view.hView))
 

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -1113,9 +1113,12 @@ proc to*(p: Coord1D, toKind: UnitKind,
 proc to*(p: Coord, toKind: UnitKind,
          absWidth = none[Quantity](), absHeight = none[Quantity](),
          datXScale = none[Scale](), datYScale = none[Scale](),
-         strText = none[string](), strFont = none[Font]()): Coord =
+         strText = none[string](), strFont = none[Font]()): Coord
+  {.deprecated: "Please use `to` for the individual `Coord1D` objects instead!".} =
   ## converts the given Coordinate position in a certain coordinate
   ## system to the same position in a target coordinate system
+  ## TODO: if we decide to keep this proc, replace it by calling `to` for
+  ## `Coord1D` on individual fields instead.
   # first convert any point to a relative point, from which we can
   # calculate any other position easiest
   case toKind

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -3021,7 +3021,7 @@ proc parseFilename(fname: string): FiletypeKind =
   else:
     result = fkPdf
 
-proc draw*(img: BImage, gobj: GraphObject) =
+proc draw*(img: var BImage, gobj: GraphObject) =
   ## draws the given graph object on the image
   let globalObj = gobj.toGlobalCoords(img)
 
@@ -3044,7 +3044,7 @@ proc draw*(img: BImage, gobj: GraphObject) =
     # composite itself has nothing to be drawn, only children handled individually
     discard
 
-proc draw(img: BImage, view: Viewport) =
+proc draw(img: var BImage, view: Viewport) =
   ## draws the full viewport including all objects and all
   ## children onto the image
   ## NOTE: children are drawn `after` the parent viewport
@@ -3052,7 +3052,7 @@ proc draw(img: BImage, view: Viewport) =
   # before we draw stuff apply potential rotation
   let (centerX, centerY) = getCenter(view)
 
-  proc transformAndDraw(img: BImage, obj: GraphObject, view: Viewport) =
+  proc transformAndDraw(img: var BImage, obj: GraphObject, view: Viewport) =
     ## performs the embedding of the object into the viewport
     ## and draws the resulting object
     var mobj = obj

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -59,7 +59,7 @@ type
     tkOneSide, # only outside the plot
     tkBothSides # inside and outside the plot
 
-  GraphObject* = object
+  GraphObject* = ref object
     name*: string # name of the Graph Object. Currently mainly used for debugging
     children*: seq[GraphObject]
     style*: Option[Style]
@@ -164,7 +164,7 @@ type
   # - implement coordinate transformations between viewport
   #   and global coordinates
   # - coordinates should be relative coordinates in [0.0, 1.0]
-  Viewport* = object
+  Viewport* = ref object
     # parameters describing the embedding into the parent
     # given relative coords
     name*: string # name of the viewport (useful for debugging)

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -1314,7 +1314,7 @@ func updateDataScale*(view: Viewport,
   for p in mitems(objs):
     view.updateDataScale(p)
 
-func updateDataScale*(view: var Viewport) =
+func updateDataScale*(view: Viewport) =
   ## Updates the data scales of all children viewports of `view` and their
   ## objects recursively
   ## Note that if `view` contains many children or children with many objects
@@ -1326,7 +1326,7 @@ func updateDataScale*(view: var Viewport) =
     # and call for child itself
     ch.updateDataScale()
 
-func addObj*(view: var Viewport, obj: GraphObject) =
+func addObj*(view: Viewport, obj: GraphObject) =
   ## adds the given `obj` to the viewport's objects and makes
   ## sure it inherits all properties, e.g. Style and data scales
   var mobj = obj
@@ -1340,7 +1340,7 @@ func addObj*(view: var Viewport, obj: GraphObject) =
   # debugecho "\n\n"
   view.objects.add mobj
 
-func addObj*(view: var Viewport, objs: varargs[GraphObject]) =
+func addObj*(view: Viewport, objs: varargs[GraphObject]) =
   ## adds the `objs` to the viewport's objects and makes
   ## sure they inherit all properties, e.g. Style and data scales
   for obj in objs:
@@ -1534,7 +1534,7 @@ proc initViewport*(left = 0.0, bottom = 0.0, width = 1.0, height = 1.0,
                         wImg = wImg, hImg = hImg,
                         backend = backend)
 
-proc addViewport*(view: var Viewport,
+proc addViewport*(view: Viewport,
                   origin: Coord,
                   width, height: Quantity,
                   style = none[Style](),
@@ -1566,7 +1566,7 @@ proc addViewport*(view: var Viewport,
   #view.children.add viewChild
   result = viewChild
 
-proc addViewport*(view: var Viewport,
+proc addViewport*(view: Viewport,
                   left = 0.0, bottom = 0.0, width = 1.0, height = 1.0,
                   style = none[Style](),
                   xScale = none[Scale](),
@@ -1691,7 +1691,7 @@ proc initText*(view: Viewport,
     result.rotate = some(rotate.get())
   setFontOrDefault(result, font)
 
-proc drawBoundary*(view: var Viewport,
+proc drawBoundary*(view: Viewport,
                    color = none[Color](),
                    writeName = false,
                    writeNumber = none[int](),
@@ -2471,7 +2471,7 @@ proc filterByBoundScale(tickPos: var seq[Coord], axKind: AxisKind,
     tickPos = tickPos.filterIt(getAx(it, axKind) >= bscale.low and
                                getAx(it, axKind) <= bscale.high)
 
-proc initTicks*(view: var Viewport,
+proc initTicks*(view: Viewport,
                 axKind: AxisKind,
                 numTicks: int = 0,
                 tickLocs: seq[Coord] = @[],
@@ -2549,7 +2549,7 @@ proc initTicks*(view: var Viewport,
     if updateScale:
       view.updateDataScale()
 
-proc xticks*(view: var Viewport,
+proc xticks*(view: Viewport,
              numTicks: int = 10,
              tickLocs: seq[Coord] = @[],
              major = true,
@@ -2571,7 +2571,7 @@ proc xticks*(view: var Viewport,
                           updateScale = updateScale,
                           isSecondary = isSecondary)
 
-proc yticks*(view: var Viewport,
+proc yticks*(view: Viewport,
              numTicks: int = 10,
              tickLocs: seq[Coord] = @[],
              major = true,
@@ -2687,7 +2687,7 @@ proc fillEmptySizesEvenly(s: seq[Quantity],
       else:
         result.add s[i]
 
-proc layout*(view: var Viewport,
+proc layout*(view: Viewport,
              cols, rows: int,
              colWidths: seq[Quantity] = @[],
              rowHeights: seq[Quantity] = @[],
@@ -2763,7 +2763,7 @@ proc layout*(view: var Viewport,
     curRowT = curRowT + view.c1(heights[i].val, akY, heights[i].unit)
   ## TODO: update width and height of the parent viewport
 
-proc background*(view: var Viewport,
+proc background*(view: Viewport,
                  style: Option[Style] = none[Style]()) =
   var r = GraphObject(kind: goRect,
                       reOrigin: initCoord(0.0, 0.0),

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -386,6 +386,7 @@ proc toRelative*(q: Quantity,
 func to*(q: Quantity, kind: UnitKind,
          length = none[Quantity](),
          scale = none[Scale]()): Quantity =
+  if q.unit == kind: return q
   case kind
   of ukPoint: q.toPoints(length = length)
   of ukInch: q.toInch()
@@ -1053,6 +1054,7 @@ proc to*(p: Coord1D, toKind: UnitKind,
   ## NOTE: this procedure is a potentially lossy conversion!
   # first check whether it's only a unit conversion between absolute values
   # in this case the conversion is loss free
+  if p.kind == toKind: return p
   if toKind in ukPoint .. ukInch and
      p.kind in ukPoint .. ukInch:
     case toKind

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -2784,14 +2784,14 @@ proc background*(view: var Viewport,
 
 
 
-proc drawLine(img: BImage, gobj: GraphObject) =
+proc drawLine(img: var BImage, gobj: GraphObject) =
   doAssert gobj.kind == goAxis or gobj.kind == goLine, "object must be a `goAxis` or `goLine`!"
   img.drawLine(gobj.lnStart.point, gobj.lnStop.point,
                gobj.style.get, # if we end up here without a style,
                                # it's a bug!
                rotateAngle = gobj.rotateInView)
 
-proc drawRect(img: BImage, gobj: GraphObject) =
+proc drawRect(img: var BImage, gobj: GraphObject) =
   doAssert gobj.kind == goRect, "object must be a `goRect`!"
   # echo "Drawing rect at ", gobj.reOrigin, " of ", gobj.reWidth, " H ", gobj.reHeight
   # echo "Style: ", gobj.style.get
@@ -2803,7 +2803,7 @@ proc drawRect(img: BImage, gobj: GraphObject) =
                     rotate = gobj.rotate,
                     rotateInView = gobj.rotateInView)
 
-proc drawPoint(img: BImage, gobj: GraphObject) =
+proc drawPoint(img: var BImage, gobj: GraphObject) =
   doAssert gobj.kind == goPoint, "object must be a `goPoint`!"
   case gobj.ptMarker
   of mkCircle:
@@ -2832,7 +2832,7 @@ proc drawPoint(img: BImage, gobj: GraphObject) =
   else:
     raise newException(Exception, "Not implemented yet!")
 
-proc drawPolyLine(img: BImage, gobj: GraphObject) =
+proc drawPolyLine(img: var BImage, gobj: GraphObject) =
   doAssert gobj.kind == goPolyLine, "object must be a `goPolyLine`!"
   # TODO: we assume that the coordinates are sorted for now
   img.drawPolyLine(gobj.plPos.mapIt((x: it.x.pos, y: it.y.pos)),
@@ -2840,7 +2840,7 @@ proc drawPolyLine(img: BImage, gobj: GraphObject) =
                    rotateAngle = gobj.rotateInView)
 
 
-proc drawText(img: BImage, gobj: GraphObject) =
+proc drawText(img: var BImage, gobj: GraphObject) =
   doAssert(
     (gobj.kind == goText or gobj.kind == goLabel or gobj.kind == goTickLabel),
     "object must be a `goText`, `goLabel` or `goTickLabel`!"
@@ -2848,7 +2848,7 @@ proc drawText(img: BImage, gobj: GraphObject) =
   img.drawText(gobj.txtText, gobj.txtFont, gobj.txtPos.point, gobj.txtAlign,
                gobj.rotate)
 
-proc drawTick(img: BImage, gobj: GraphObject) =
+proc drawTick(img: var BImage, gobj: GraphObject) =
   ## draw a tick
   doAssert gobj.kind == goTick, "object must be a `goTick`!"
   var style = gobj.style.get() # style *has* to exist
@@ -2893,7 +2893,7 @@ proc drawTick(img: BImage, gobj: GraphObject) =
                  style,
                  rotateAngle = gobj.rotateInView)
 
-proc drawGrid(img: BImage, gobj: GraphObject) =
+proc drawGrid(img: var BImage, gobj: GraphObject) =
   ## draws the (major / minor) grid
   doAssert gobj.kind == goGrid, "object must be a `goGrid`!"
   var style = gobj.style.get() # style *has* to exist

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -2908,15 +2908,14 @@ proc scale[T: SomeNumber](p: Point, width, height: T): Point =
   result = (p.x * width.float,
             p.y * height.float)
 
-proc toAbsImage(c: Coord1D, img: BImage, axKind: AxisKind): Coord1D =
+proc toAbsImage(c: Coord1D, img: BImage, axKind: AxisKind): Coord1D {.inline.} =
   case axKind
   of akX: result = c.to(ukPoint, absLength = some(quant(img.width.float, ukPoint)))
   of akY: result = c.to(ukPoint, absLength = some(quant(img.height.float, ukPoint)))
 
-proc toAbsImage(c: Coord, img: BImage): Coord =
-  result = c.to(ukPoint,
-                absWidth = some(quant(img.width.float, ukPoint)),
-                absHeight = some(quant(img.height.float, ukPoint)))
+proc toAbsImage(c: Coord, img: BImage): Coord {.inline.} =
+  result.x = c.x.toAbsImage(img, akX)
+  result.y = c.y.toAbsImage(img, akY)
 
 proc toGlobalCoords(gobj: GraphObject, img: BImage): GraphObject =
   result = gobj

--- a/src/ginger/backendCairo.nim
+++ b/src/ginger/backendCairo.nim
@@ -201,7 +201,6 @@ proc drawText*(img: var BImage, text: string, font: Font, at: Point,
 
 proc createGradient(gradient: Gradient,
                     left, bottom, width, height: float): PPattern =
-  echo left, " ", bottom, " ", width, " ", height
   let middle = bottom + height / 2.0
   let right = left + width
   let center = left + width / 2.0

--- a/src/ginger/backends.nim
+++ b/src/ginger/backends.nim
@@ -18,6 +18,8 @@ when not defined(noCairo):
         let err = img.cCanvas.write_to_png(img.fname)
         echo err, " output of write_to_png"
       else: discard # not needed for SVG, PDF
+      if img.created:
+        img.ctx.destroy()
       img.cCanvas.destroy()
     of bkVega:
       discard

--- a/src/ginger/types.nim
+++ b/src/ginger/types.nim
@@ -40,6 +40,8 @@ type
     case backend*: BackendKind
     of bkCairo:
       cCanvas*: PSurface
+      ctx*: PContext
+      created*: bool # if surface was created
       ftype*: FileTypeKind
     of bkVega:
       discard

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -213,10 +213,18 @@ suite "Viewport":
                              height = 0.5,
                              xScale = some(xScale),
                              yScale = some(yScale))
-    var oldChild = deepCopy(child)
+    var oldChild: Viewport
+    when defined(gcDestructors):
+      oldChild[] = child[]
+    else:
+      oldChild = deepCopy(child)
     block:
       # x ticks and labels
-      var mch = deepCopy(oldChild)
+      var mch: Viewport
+      when defined(gcDestructors):
+        mch[] = oldChild[]
+      else:
+        mch = deepCopy(oldChild)
       let xTicks = child.xticks()
       let xLabel = child.xlabel("X label")
       mch.addObj concat(xticks, @[xlabel])
@@ -233,7 +241,11 @@ suite "Viewport":
 
     block:
       # rotated tick labels and labels, X axis
-      var mch = deepCopy(oldChild)
+      var mch: Viewport
+      when defined(gcDestructors):
+        mch[] = oldChild[]
+      else:
+        mch = deepCopy(oldChild)
       let ticksLabs = block:
                     var locsC: seq[Coord1D]
                     let locs = linspace(0.1, 0.9, 5)
@@ -262,7 +274,11 @@ suite "Viewport":
 
     block:
       # y ticks and labels
-      var mch = deepCopy(oldChild)
+      var mch: Viewport
+      when defined(gcDestructors):
+        mch[] = oldChild[]
+      else:
+        mch = deepCopy(oldChild)
       let yTicks = child.yticks()
       let yLabel = child.ylabel("Y label")
       mch.addObj concat(yticks, @[ylabel])
@@ -279,7 +295,11 @@ suite "Viewport":
 
     block:
       # rotated tick labels and labels, Y axis
-      var mch = deepCopy(oldChild)
+      var mch: Viewport
+      when defined(gcDestructors):
+        mch[] = oldChild[]
+      else:
+        mch = deepCopy(oldChild)
       let ticksLabs = block:
                     var locsC: seq[Coord1D]
                     let locs = linspace(0.1, 0.9, 5)
@@ -308,7 +328,11 @@ suite "Viewport":
 
     block:
       # x ticks and labels, secondary
-      var mch = deepCopy(oldChild)
+      var mch: Viewport
+      when defined(gcDestructors):
+        mch[] = oldChild[]
+      else:
+        mch = deepCopy(oldChild)
       let xTicks = child.xticks(isSecondary = true)
       let xLabel = child.xlabel("X label sec", isSecondary = true)
       mch.addObj concat(xticks, @[xlabel])
@@ -325,7 +349,11 @@ suite "Viewport":
         else: check false
     block:
       # y ticks and labels
-      var mch = deepCopy(oldChild)
+      var mch: Viewport
+      when defined(gcDestructors):
+        mch[] = oldChild[]
+      else:
+        mch = deepCopy(oldChild)
       let yTicks = child.yticks(isSecondary =  true)
       let yLabel = child.ylabel("Y label sec", isSecondary = true)
       mch.addObj concat(yticks, @[ylabel])

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -213,10 +213,10 @@ suite "Viewport":
                              height = 0.5,
                              xScale = some(xScale),
                              yScale = some(yScale))
-    var oldChild = child
+    var oldChild = deepCopy(child)
     block:
       # x ticks and labels
-      var mch = oldChild
+      var mch = deepCopy(oldChild)
       let xTicks = child.xticks()
       let xLabel = child.xlabel("X label")
       mch.addObj concat(xticks, @[xlabel])
@@ -233,7 +233,7 @@ suite "Viewport":
 
     block:
       # rotated tick labels and labels, X axis
-      var mch = oldChild
+      var mch = deepCopy(oldChild)
       let ticksLabs = block:
                     var locsC: seq[Coord1D]
                     let locs = linspace(0.1, 0.9, 5)
@@ -262,7 +262,7 @@ suite "Viewport":
 
     block:
       # y ticks and labels
-      var mch = oldChild
+      var mch = deepCopy(oldChild)
       let yTicks = child.yticks()
       let yLabel = child.ylabel("Y label")
       mch.addObj concat(yticks, @[ylabel])
@@ -279,7 +279,7 @@ suite "Viewport":
 
     block:
       # rotated tick labels and labels, Y axis
-      var mch = oldChild
+      var mch = deepCopy(oldChild)
       let ticksLabs = block:
                     var locsC: seq[Coord1D]
                     let locs = linspace(0.1, 0.9, 5)
@@ -308,7 +308,7 @@ suite "Viewport":
 
     block:
       # x ticks and labels, secondary
-      var mch = oldChild
+      var mch = deepCopy(oldChild)
       let xTicks = child.xticks(isSecondary = true)
       let xLabel = child.xlabel("X label sec", isSecondary = true)
       mch.addObj concat(xticks, @[xlabel])
@@ -325,7 +325,7 @@ suite "Viewport":
         else: check false
     block:
       # y ticks and labels
-      var mch = oldChild
+      var mch = deepCopy(oldChild)
       let yTicks = child.yticks(isSecondary =  true)
       let yLabel = child.ylabel("Y label sec", isSecondary = true)
       mch.addObj concat(yticks, @[ylabel])


### PR DESCRIPTION
This PR introduces changes, which were based on a simple performance test using the following `ggplotnim` code:

```nim
const num = 1_000_000
var xs = newSeq[float](num)
var ys = newSeq[float](num)
for i in 0 ..< num:
  xs[i] = random(1.0)
  ys[i] = random(1.0)
let df = seqsToDf(xs, ys)
ggplot(df, aes("xs", "ys")) +
  geom_point(size = some(0.1)) +
  ggsave("million_points.pdf")
```

Which I ran with different settings.

Tests:
compile with `nim c -d:danger million.nim`
- current impl:
  - 7 GB of RAM usage
  - time: 30s
- make Viewport a ref object:
  - 2.26 GB RAM
  - 19.55 s
- leave Viewport, make GraphObject a ref object
  - 1.85 GB RAM
  - 16.5 s
- both ref object
  - 1.72 GB RAM
  - 16.1 s

So from that it seems like the majority of the RAM is actually
due to GraphObjects, which makes sense for 1 Mio points.

Scaling to 5 Mio with both ref:
- 8.5 GB of RAM
- 80 s

Make Value a ref object
- 8.6 GB of RAM
- 82 s

Before these changes the program wouldn't even finish with 5 Mio. points. It's an improvement, but I'm aware that these numbers are still excessive.

Aside from that the PR includes a few minor fixes. Some procs were streamlined a bit, and `layout` now uses the `ignoreOverflow` flag if given.

The full changelog:

* v0.1.18
- fix remaining places, which are supposed to use =pointWidth/Height=
- make =ignoreOverflow= work for =layout= (was previously ignored),
  which allows for total heights / widhts larger than the
  viewport. Better to have overflowing viewports than crash if
  desired!
- simplify =toAbsImage= implementation, calls =to= for each =Coord=
  field instead now.
- deprecate =to= for =Coord=. Use =to= for =Coord1D= instead on each
  field!
- =to= now return early if input already has output type
- =BImage= now has a =PContext= field. Instead of creating a context
  for each field, we now keep a global one, whose state we save and
  revert. 
- =Viewport= and =GraphObject= are now =ref objects= to avoid costly
  copies, if we have large objects in =ggplotnim=. Reduces memory
  footprint for plots with many elements significantly (1 Mio. point
  scatter plot before 8.5 GB (!!!), now *cough* only 1.7 GB). 
