### PR TITLE
Fix arithmetic for coordinates involving ukData

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,7 @@
+* v0.2.2
+- fixes arithmetic for coordinates involving =ukData= kinds
+- fix string representation for =goComposite=
+
 * v0.2.1
 Hotfix release, which adds the missing =PContext= object for the dummy
 backend, which is used to test on travis in ggplotnim.

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -374,7 +374,10 @@ proc toRelative*(q: Quantity,
   of ukData:
     info "[INFO]: conversion of ukData quant to relative. Assuming `length` is data scale!"
     if scale.isSome:
-      result = quant(q.val / (scale.unsafeGet.high - scale.unsafeGet.low), ukRelative)
+      let sc = scale.unsafeGet
+      # NOTE: we do ``not`` subtract the lower scale from `q.val`, because this is
+      # a ``quantity`` and not a ccoordinate!
+      result = quant(q.val / (sc.high - sc.low), ukRelative)
     else:
       raise newException(Exception, "Need a scale to convert quantity of kind " &
         "`ukData` to relative!")

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -739,7 +739,7 @@ func pretty*(gobj: GraphObject, indent = 0): string =
   else:
     result &= "\n"
   for ch in gobj.children:
-    result = pretty(ch, indent + 2)
+    result &= pretty(ch, indent + 2)
   result &= ")\n"
 
 func `$`*(gobj: GraphObject): string =

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -437,3 +437,37 @@ suite "Viewport":
         ch.checkRecurse()
 
     plt.checkRecurse()
+
+  test "Arithmetic for `Coord1D` involving ukData":
+
+    let q1 = quant(50.0, ukData)
+    let scale = (low: 25.0, high: 125.0)
+
+    # sanity check. Conversion to `ukRelative` for a quantity
+    # is handlded correctly
+    check q1.toRelative(scale = some(scale)) == quant(0.5, ukRelative)
+
+    # now for math involving ukData coordinates. In this case the
+    # subtraction should be
+    let exp = quant(q1.val - scale.low, ukData).toRelative(scale = some(scale))
+
+    let cd1 = Coord1D(kind: ukData,
+                      pos: 50.0,
+                      scale: scale,
+                      axis: akX)
+    let cd2 = Coord1D(kind: ukPoint,
+                      pos: 10.0,
+                      length: some(quant(100.0, ukPoint)))
+    let cd3 = Coord1D(kind: ukPoint,
+                      pos: 0.0,
+                      length: some(quant(100.0, ukPoint)))
+
+    let cd12 = cd1 - cd2
+    check cd12.pos == 0.15
+    check cd12.kind == ukRelative
+
+    let cd13 = cd1 - cd3
+    check cd13.pos == 0.25
+    # this should be the same as `exp`
+    check cd13.pos == exp.val
+    check cd13.kind == ukRelative


### PR DESCRIPTION
Aside from fixing arithmetic (see below) this also fixes the string representation for `goComposite` objects.

From the commit:
```
In the arithmetic procs for Coord1D we use `sub, add, times,
divide`. However, in those we may (for ukData kind) convert the uk
data coord to a relative quantity.

However, if the quantity for which `toRelative` from ukData is called
represents a coordinate, the following line:
rel = q.val / (scale.high - scale.low)
is obviously wrong, since that gives us the quantity `q.val` reresents
on a scale defined by `scale.high - scale.low`.

Thus we have a new `asCoordinate` argument for quantity sub,
... procs, which first subtract the `scale.low` value from `q.val` to
essentially get the correct result for a coordinate.
```