### PR TITLE
convert tick label positions to relative

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,6 @@
+* v0.2.3
+- make tick label positions relative. For plots that are embedded this
+  is important to keep the labels where they belong.
 * v0.2.2
 - fixes arithmetic for coordinates involving =ukData= kinds
 - fix string representation for =goComposite=

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -2279,11 +2279,10 @@ proc initTickLabel(view: Viewport,
   let alignTo = setTextAlignKind(tick.tkAxis, isSecondary, alignToOverride)
   case tick.tkAxis
   of akX:
-    let yCoord = XAxisYPos(isSecondary = isSecondary)
     let yOffset = if margin.isSome: margin.unsafeGet
                   else: yLabelOriginOffset(isSecondary)
     origin = Coord(x: loc.x,
-                   y: yCoord + yOffset)
+                   y: (loc.y + yOffset).toRelative)
     case loc.x.kind
     of ukData:
       let scale = loc.x.scale
@@ -2304,10 +2303,9 @@ proc initTickLabel(view: Viewport,
                            rotate = rotate,
                            name = gobjName)
   of akY:
-    let xCoord = YAxisXPos(isSecondary = isSecondary)
     let xOffset = if margin.isSome: margin.unsafeGet
                   else: xLabelOriginOffset(isSecondary)
-    origin = Coord(x: xCoord + xOffset,
+    origin = Coord(x: (loc.x + xOffset).toRelative,
                    y: loc.y)
     case loc.y.kind
     of ukData:


### PR DESCRIPTION
While we want to be able to use absolute units when adding a margin to
a tick label, keeping it as absolute is problematic, because the
position then won't be properly moved when being embedded. For facet
plots in ggplotnim this results in x tick labels, which are not
actually at the plot, but still at the bottom of the plot.