### PR TITLE
Update the cairo dep version to 1.1.1

### DIFF
--- a/ginger.nimble
+++ b/ginger.nimble
@@ -12,7 +12,7 @@ srcDir        = "src"
 requires "nim >= 1.0.0"
 requires "chroma >= 0.1.0"
 requires "https://github.com/vindaar/seqmath >= 0.1.7"
-requires "cairo"
+requires "cairo >= 1.1.1"
 
 task test, "Run tests":
   exec "nim c -r tests/test1.nim"


### PR DESCRIPTION
Older cairo version 1.1.0 installed with a `cairo.babel` instead of `cairo.nimble` and that caused issues when running `nim doc --project ..`. As the `cairo.babel` isn't recognized as a Nimble pkg file, `nim doc` thought of `cairo`, as a user packages and clubbed its documentation along with ther user's packages. This resulted in https://github.com/nim-lang/Nim/issues/14453.

Updating the minimum cairo version to 1.1.1 will ensure that a cairo version with a .nimble gets installed.