### PR TITLE
fix to unblock https://github.com/nim-lang/Nim/pull/14869

### DIFF
--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -14,6 +14,8 @@ export types, backends, macroUtils
 
 from os import splitFile
 
+proc byLent[T](a: T): lent T {.inline.} = a # pending https://github.com/nim-lang/Nim/pull/14875
+
 # TODO: think about renaming `Coord1D` to someting like Unit?
 
 # TODO: implement some more units so that we can use it to define
@@ -1355,14 +1357,14 @@ func updateDataScale(view: Viewport, obj: var GraphObject) =
   of goLabel, goText, goTickLabel:
     view.updateScale(obj.txtPos)
   of goGrid:
-    obj.gdXPos.applyIt(view.updateScale(it))
-    obj.gdYPos.applyIt(view.updateScale(it))
+    obj.gdXPos.applyIt(view.updateScale(it.byLent))
+    obj.gdYPos.applyIt(view.updateScale(it.byLent))
   of goTick:
     view.updateScale(obj.tkPos)
   of goPoint:
     view.updateScale(obj.ptPos)
   of goPolyLine:
-    obj.plPos.applyIt(view.updateScale(it))
+    obj.plPos.applyIt(view.updateScale(it.byLent))
   of goRect:
     view.updateScale(obj.reOrigin)
   of goRaster:


### PR DESCRIPTION
/cc @Vindaar somehow your packages are my usual suspect PR blockers; that's actually a good thing because it's better to catch problems early on (and figure out good solutions) before a PR is merged rather than "in the wild". So thanks for breaking my PR's ;-)

before this PR:
https://github.com/nim-lang/Nim/pull/14869 fails only because of this package, giving:

```
2020-07-01T10:34:35.1005100Z [1m[31mFAIL: [36mhttps://github.com/Vindaar/ggplotnim C[0m
2020-07-01T10:34:35.1006090Z [1m[36mTest "https://github.com/Vindaar/ggplotnim" in category "nimble-packages-1"[0m
2020-07-01T10:34:35.1008480Z [1m[31mFailure: reBuildFailed[0m
2020-07-01T10:34:35.1015110Z package test failed
2020-07-01T10:34:35.1015800Z $ nim c -d:noCairo -r tests/tests.nim
2020-07-01T10:34:35.1017100Z Hint: used config file '/Users/runner/runners/2.263.0/work/Nim/Nim/config/nim.cfg' [Conf]
2020-07-01T10:34:35.1017970Z Hint: used config file '/Users/runner/runners/2.263.0/work/Nim/Nim/config/config.nims' [Conf]
2020-07-01T10:34:35.1019110Z Hint: used config file '/Users/runner/runners/2.263.0/work/Nim/Nim/pkgstemp/ggplotnim/tests/config.nims' [Conf]
2020-07-01T10:34:35.1019690Z ...............................................
2020-07-01T10:34:35.1020690Z /Users/runner/.nimble/pkgs/ginger-0.2.5/ginger.nim(1358, 40) Error: expression 'updateScale(view, it)' has no type (or is ambiguous)
2020-07-01T10:34:35.1020890Z 
```


after this PR:
it works.

* I'm inlining the definition of `byLent` (see https://github.com/nim-lang/Nim/pull/14875), feel free to remove and use `from std/decls import byLent` after https://github.com/nim-lang/Nim/pull/14875 has been merged.

* https://github.com/nim-lang/Nim/pull/14869 makes `applyIt` more efficient (avoid un-needed copies) and more correct (wrt template param duplication evaluation bugs)

