### PR TITLE
Fix multiline spacing

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,5 @@
+* v0.2.7
+- fix the spacing for multi line text. The reference height was wrong.
 * v0.2.6
 - allow assignment of axis in =initCoord1D= proc / template using it,
   use that in =initCoord= proc / template for =ukData=

--- a/ginger.nimble
+++ b/ginger.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.6"
+version       = "0.2.7"
 author        = "Vindaar"
 description   = "A Grid (R) like package in Nim"
 license       = "MIT"

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -1889,8 +1889,8 @@ proc initMultiLineText*(view: Viewport,
     # and an additional (-0.5 * height) to account for current text being
     # centered on center of line, not bottom
     let newY = origin.y - toRelative(
-      strHeight((numLines.float - idx.float - 0.5).float * 1.75, font),
-      length = some(view.hImg)
+      strHeight((numLines.float - idx.float - 0.5).float * 1.5, font),
+      length = some(view.pointHeight)
     )
     let newOrigin = Coord(x: origin.x,
                           y: newY)


### PR DESCRIPTION
The spacing was not correct when calculating the position of different lines in multi line text due to a wrong reference height in use.