### PR TITLE
fix margin in `layout`, change default tick label margin

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,7 @@
+* v0.2.10
+- change default tick label margin to be based on font height
+- fix margin handling in layout to be based on relative sizes of the
+  *current* viewport instead of the parent viewport
 * v0.2.9
 - add "Secondary" suffix to the names of tick labels of secondary axes
 * v0.2.8

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -2267,26 +2267,23 @@ proc ylabel*(view: Viewport,
                               isSecondary = isSecondary,
                               rotate = rotate)
 
-template xLabelOriginOffset(isSecondary = false): untyped =
+template xLabelOriginOffset(fnt: Font, isSecondary = false): untyped =
   if not isSecondary:
-    Coord1D(pos: -0.4,
-            kind: ukCentimeter,
-            length: some(pointWidth(view)))
+    # use `M` as default
+    Coord1D(pos: -1.25, kind: ukStrHeight, text: "M", font: fnt)
+      .toRelative(length = some(pointWidth(view)))
   else:
-    Coord1D(pos: 0.4,
-            kind: ukCentimeter,
-            length: some(pointWidth(view)))
+    Coord1D(pos: 1.25, kind: ukStrHeight, text: "M", font: fnt)
+      .toRelative(length = some(pointWidth(view)))
 
-template yLabelOriginOffset(isSecondary = false): untyped =
+template yLabelOriginOffset(fnt: Font, isSecondary = false): untyped =
   if not isSecondary:
-    Coord1D(pos: 0.5,
-            kind: ukCentimeter,
-            length: some(pointHeight(view)))
+    # use `M` as default
+    Coord1D(pos: 1.75, kind: ukStrHeight, text: "M", font: fnt)
+      .toRelative(length = some(pointHeight(view)))
   else:
-    # TODO: check if value good!
-    Coord1D(pos: -0.5,
-            kind: ukCentimeter,
-            length: some(pointHeight(view)))
+    Coord1D(pos: -1.75, kind: ukStrHeight, text: "M", font: fnt)
+      .toRelative(length = some(pointHeight(view)))
 
 proc setTextAlignKind(axKind: AxisKind,
                       isSecondary = false,
@@ -2314,7 +2311,7 @@ proc initTickLabel(view: Viewport,
                    isSecondary = false,
                    alignToOverride = none[TextAlignKind]()): GraphObject =
   doAssert tick.kind == goTick, "object must be a `goTick` to create a `goTickLabel`!"
-  let mfont = if font.isNone: some(defaultFont(8.0)) else: font
+  let mfont = if font.isNone: defaultFont(8.0) else: font.get
   var label: GraphObject
   var gobjName = name
   var origin: Coord
@@ -2324,7 +2321,7 @@ proc initTickLabel(view: Viewport,
   case tick.tkAxis
   of akX:
     let yOffset = if margin.isSome: margin.unsafeGet
-                  else: yLabelOriginOffset(isSecondary)
+                  else: yLabelOriginOffset(mfont, isSecondary)
     origin = Coord(x: loc.x,
                    y: (loc.y + yOffset).toRelative)
     if gobjName == "tickLabel":
@@ -2333,12 +2330,12 @@ proc initTickLabel(view: Viewport,
         gobjName &= "Secondary"
     result = view.initText(origin, labelTxt, textKind = goTickLabel,
                            alignKind = alignTo,
-                           font = mfont,
+                           font = some(mfont),
                            rotate = rotate,
                            name = gobjName)
   of akY:
     let xOffset = if margin.isSome: margin.unsafeGet
-                  else: xLabelOriginOffset(isSecondary)
+                  else: xLabelOriginOffset(mfont, isSecondary)
     origin = Coord(x: (loc.x + xOffset).toRelative,
                    y: loc.y)
     if gobjName == "tickLabel":
@@ -2348,7 +2345,7 @@ proc initTickLabel(view: Viewport,
     result = view.initText(origin, labelTxt,
                            textKind = goTickLabel,
                            alignKind = alignTo,
-                           font = mfont,
+                           font = some(mfont),
                            rotate = rotate,
                            name = gobjName)
 

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -2816,14 +2816,19 @@ proc layout*(view: Viewport,
                                       scale = some(view.xScale))
       let marginY = margin.toRelative(length = some(pointHeight(view)),
                                       scale = some(view.yScale))
+      ## Margins are 2 times given margin in relative units relative to the width of a single
+      ## viewport in the resulting layout!
+      ## TODO: possibly given `colWidths`?
       let width = sub(widths[j],
                       times(quant(2.0, ukRelative), marginX,
-                            length = some(pointWidth(view)),
+                            length = some(quant(pointWidth(view).val / cols.float,
+                                                ukPoint)),
                             scale = some(view.xScale)),
                       length = some(pointWidth(view)),
                       scale = some(view.xScale))
       let height = sub(heights[i], times(quant(2.0, ukRelative), marginY,
-                                         length = some(pointHeight(view)),
+                                         length = some(quant(pointHeight(view).val / rows.float,
+                                                             ukPoint)),
                                          scale = some(view.yScale)),
                        length = some(pointHeight(view)),
                        scale = some(view.yScale))


### PR DESCRIPTION
The given `margin` to the `layout` procedure now bases the relative width on the individual viewport's size instead of the size of the parent viewport. This fixes random scaling of the apparent margin when the number of plots e.g. in a facet changed.

Also changes the default tick label margin to be based on the font height.