### PR TITLE
Fix downstream errorbar issue (ggplotnim #94)

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,6 @@
+* v0.2.11
+- fix downstream =ggplotnim= issue #94:
+  https://github.com/Vindaar/ggplotnim/issues/94
 * v0.2.10
 - change default tick label margin to be based on font height
 - fix margin handling in layout to be based on relative sizes of the

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -1992,31 +1992,19 @@ proc initErrorBar*(view: Viewport,
             size: 10.0) # describes length of orthogonal line of `ebLinesT`
     )
   # in case the user hands the errors as `ukData`, update the scale
-  #doAssert pt.ptPos.isScaleNonTrivial, "Data scale must be non trivial!"
-  #var
-  #  # error variables with appropriate scales, if `ukData`
-  #  errUp: Coord1D
-  #  errDown: Coord1D
-  #errUp = view.updateScale(errorUp)
-  #errDown = view.updateScale(errorDown)
   template createLines(axKind, x1, x2, y1, y2: untyped): untyped =
-    let chUp = view.initLine(
-      start = pt,
-      stop = Coord(
+    let line = view.initLine(
+      start = Coord(
         x: x1,
         y: y1
       ),
-      style = style
-    )
-    let chDown = view.initLine(
-      start = pt,
       stop = Coord(
         x: x2,
         y: y2,
       ),
       style = style
     )
-    result.children = @[chDown, chUp]
+    result.children = @[line]
 
   case ebKind
   of ebLines:


### PR DESCRIPTION
This fixes the issue encountered in:

https://github.com/Vindaar/ggplotnim/issues/94

The problem was the way we compute the location of the bottom to top lines for X error bars if drawn with `T` style. In that case our computation yielded a `ukRelative`. In the context though that's not great, because the `ukRelative` will be interpreted from *the top* while drawing.

I'm personally confused as to *why* `ukRelative` is interpreted as being from the top in case of relative, but whatever for now.