### PR TITLE
TikZ backend

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,8 @@
+* v0.3.0
+- implements the TikZ backend for native LaTeX plots. Either
+  generation of TeX code using TikZ or direct compilation by calling
+  =xelatex/pdflatex=
+  
 * v0.2.12
 - fix height used in =getStrHeight= to determine height of multiple
   lines

--- a/ginger.nimble
+++ b/ginger.nimble
@@ -13,6 +13,8 @@ requires "nim >= 1.0.0"
 requires "chroma >= 0.1.0"
 requires "https://github.com/Vindaar/seqmath >= 0.1.7"
 requires "cairo >= 1.1.1"
+requires "https://github.com/Vindaar/LatexDSL >= 0.1.4"
+requires "shell"
 
 task test, "Run tests":
   exec "nim c -r tests/test1.nim"

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -3204,17 +3204,17 @@ proc draw*(img: var BImage, view: Viewport) =
     img.draw(mchView)
 
 when not defined(noCairo):
-  proc draw*(view: Viewport, filename: string) =
+  proc draw*(view: Viewport, filename: string, texOptions: TeXOptions) =
     ## draws the given viewport and all its children and stores it in the
     ## file `filename`
     let ftype = parseFilename(filename)
-    let backend = if ftype == fkTeX: bkTikZ else: bkCairo
     var img = initBImage(filename,
                          width = view.wImg.val.round.int, height = view.hImg.val.round.int,
-                         backend = backend,
-                         ftype = ftype)
+                         ftype = ftype,
+                         texOptions = texOptions)
     img.draw(view)
     img.destroy()
+
 else:
   proc draw*(view: Viewport, filename: string) =
     static: echo "Compiling draw as a dummy proc"

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -3130,6 +3130,8 @@ proc parseFilename(fname: string): FiletypeKind =
     result = fkSvg
   of ".png":
     result = fkPng
+  of ".tex":
+    result = fkTeX
   else:
     result = fkPdf
 
@@ -3206,9 +3208,10 @@ when not defined(noCairo):
     ## draws the given viewport and all its children and stores it in the
     ## file `filename`
     let ftype = parseFilename(filename)
+    let backend = if ftype == fkTeX: bkTikZ else: bkCairo
     var img = initBImage(filename,
                          width = view.wImg.val.round.int, height = view.hImg.val.round.int,
-                         backend = view.backend,
+                         backend = backend,
                          ftype = ftype)
     img.draw(view)
     img.destroy()

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -3204,7 +3204,7 @@ proc draw*(img: var BImage, view: Viewport) =
     img.draw(mchView)
 
 when not defined(noCairo):
-  proc draw*(view: Viewport, filename: string, texOptions: TeXOptions) =
+  proc draw*(view: Viewport, filename: string, texOptions: TeXOptions = TeXOptions()) =
     ## draws the given viewport and all its children and stores it in the
     ## file `filename`
     let ftype = parseFilename(filename)

--- a/src/ginger/backendCairo.nim
+++ b/src/ginger/backendCairo.nim
@@ -290,29 +290,24 @@ proc drawRaster*(img: var BImage, left, bottom, width, height: float,
 
 proc initBImage*(filename: string,
                  width, height: int,
-                 backend: BackendKind,
                  fType: FiletypeKind): BImage =
-  case backend
-  of bkCairo:
-    var surface: PSurface
-    case fType:
-    of fkPng:
-      surface = image_surface_create(FORMAT_ARGB32, width.int32, height.int32)
-    of fkSvg:
-      surface = svg_surface_create(filename, width.float, height.float)
-    of fkPdf:
-      surface = pdf_surface_create(filename, width.float, height.float)
-    else:
-      raise newException(Exception, "Unsupported fType " & $fType & " in `initBImage")
-    result = BImage(fname: filename,
-                    backend: bkCairo,
-                    created: false,
-                    cCanvas: surface,
-                    width: width,
-                    height: height,
-                    fType: fType)
-  of bkVega:
-    discard
+  var surface: PSurface
+  case fType:
+  of fkPng:
+    surface = image_surface_create(FORMAT_ARGB32, width.int32, height.int32)
+  of fkSvg:
+    surface = svg_surface_create(filename, width.float, height.float)
+  of fkPdf:
+    surface = pdf_surface_create(filename, width.float, height.float)
+  else:
+    raise newException(Exception, "Unsupported fType " & $fType & " in `initBImage")
+  result = BImage(fname: filename,
+                  backend: bkCairo,
+                  created: false,
+                  cCanvas: surface,
+                  width: width,
+                  height: height,
+                  fType: fType)
 
 when isMainModule:
   # raw Cairo code

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -222,12 +222,19 @@ proc drawRectangle*(img: var BImage, left, bottom, width, height: float,
       `color`
       \draw `lineSt` `atStr` rectangle `sizeStr` ";"
 
-proc drawRaster*(img: var BImage, left, bottom, width, height: float,
+from backendCairo import nil
+proc drawRaster*(img: var BImage, name: string, left, bottom, width, height: float,
                  numX, numY: int,
                  drawCb: proc(): seq[uint32],
                  rotate: Option[float] = none[float](),
                  rotateInView: Option[(float, Point),] = none[(float, Point)]()) =
-  debugecho "WARNING: `drawRaster` of TikZ backend is not implemented yet!"
+  ## draw raster by using Cairo to draw the actual raster and store it as a png. That we
+  ## include here
+  # embedding a picture using a node places ``center`` of picture at `atStr` coord
+  let atStr = img.toStr((x: left + width / 2.0, y: bottom + height / 2.0))
+  let w = width / img.width.float
+  latexAdd:
+    \node at `atStr` {\includegraphics[width = `w`\textwidth]{`name`}}";"
 
 proc initBImage*(filename: string,
                  width, height: int,

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -55,9 +55,9 @@ template latexAdd(body: untyped): untyped {.dirty.} =
   img.data.add toAdd
 
 proc defColor(name: string, c: Color): string =
-  let color = &"{c.r * 256.0}, {c.g * 256.0}, {c.b * 256.0}"
+  let color = &"{c.r}, {c.g}, {c.b}"
   result = latex:
-    \definecolor{`name`}{RGB}{`color`}
+    \definecolor{`name`}{rgb}{`color`}
 
 proc colorStr(style: Style): string =
   result.add defColor("drawColor", style.color)

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -63,11 +63,40 @@ proc colorStr(style: Style): string =
   result.add defColor("drawColor", style.color)
   result.add defColor("fillColor", style.fillColor)
 
+func getLineStyle(lineType: LineType, lineWidth: float): string =
+  template dash: untyped = lineWidth * 4.0
+  template dashSpace: untyped = lineWidth * 5.0
+  template dot: untyped = lineWidth / 2.0
+  template dotSpace: untyped = lineWidth * 2.0
+  template longDash: untyped = lineWidth * 8.0
+
+  case lineType
+  of ltDashed:
+    result = latex:
+      dash pattern = on $(dash())pt off $(dashSpace())pt
+  of ltDotted:
+    result = latex:
+      dash pattern = on $(dot())pt off $(dotSpace())pt
+  of ltDotDash:
+    result = latex:
+      dash pattern = on $(dot())pt off $(dotSpace()) on $(dash())pt off $(dotSpace())
+  of ltLongDash:
+    result = latex:
+      dash pattern = on $(longDash())pt off $(dashSpace())
+  of ltTwoDash:
+    result = latex:
+      dash pattern = on $(dash())pt off $(dotSpace() * 2.0) on $(longDash())pt off $(dotSpace() * 2.0)
+  else: discard
+
 proc lineStyle(style: Style, drawColor = "drawColor", fillColor = "fillColor"): string =
-  #let color = "{" & &"{style.color.r * 256.0}, {style.color.g * 256.0}, {style.color.b * 256.0}" & "}"
   let fillOp = &"fill opacity = {style.fillColor.a}"
   let colorOp = &"draw opacity = {style.color.a}"
-  result = &"[color = {drawColor}, fill = {fillColor}, {colorOp}, {fillOp}, line width = {style.lineWidth}pt]"
+  let lineDash = getLineStyle(style.lineType, style.lineWidth)
+  result = &"[color = {drawColor}, fill = {fillColor}, {colorOp}, {fillOp}, line width = {style.lineWidth}pt"
+  if lineDash.len > 0:
+    result.add ", " & lineDash & "]"
+  else:
+    result.add "]"
 
 proc drawLine*(img: var BImage, start, stop: Point,
                style: Style,

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -1,0 +1,103 @@
+import chroma
+import math
+import types
+import options
+
+import os, latexdsl, strformat
+
+#[
+Maybe we have to collect all colors in a table or seq and create a custom 'preamble' that
+contains color definitons?
+]#
+
+template toStr(p: Point): string {.dirty.} =
+  block:
+    let pst = (x: p.x / img.width.float, y: (img.height.float - p.y) / img.height.float)
+    &"({pst.x}\\textwidth, {pst.y}\\textwidth)"
+
+template latexAdd(body: untyped): untyped {.dirty.} =
+  let toAdd = latex:
+    body
+  img.data.add toAdd
+
+proc drawLine*(img: var BImage, start, stop: Point,
+               style: Style,
+               rotateAngle: Option[(float, Point)] = none[(float, Point)]()) =
+  let p0 = start.toStr
+  let p1 = stop.toStr
+  let colors = &"{style.color.r}, {style.color.g}, {style.color.b}" # , {style.color.a}
+  let color = latex:
+    \definecolor{foocolor}{RGB}{`colors`}
+  let lineWidth = &"[line width = {style.lineWidth}pt, fill = foocolor]"
+  #,fill={rgb:red,4;green,2;yellow,1}
+  latexAdd:
+    `color`
+    \draw " " `lineWidth` " " `p0` " " -- " " `p1` ";"
+
+proc drawPolyLine*(img: var BImage, points: seq[Point],
+                   style: Style,
+                   rotateAngle: Option[(float, Point)] = none[(float, Point)]()) =
+  latexAdd:
+    \draw
+  for i, p in points:
+    let pStr = p.toStr
+    if i == points.high:
+      latexAdd:
+        `pStr`
+    else:
+      latexAdd:
+        `pStr` " -- "
+  img.data.add ";"
+
+proc drawCircle*(img: var BImage, center: Point, radius: float,
+                 lineWidth: float,
+                 strokeColor = color(0.0, 0.0, 0.0),
+                 fillColor = color(0.0, 0.0, 0.0, 0.0),
+                 rotateAngle: Option[(float, Point)] = none[(float, Point)]()) =
+  let p = center.toStr
+  latexAdd:
+    \draw " " `p` " " circle " " [radius = `radius`] ";"
+
+proc getTextExtent*(text: string, font: Font): TextExtent =
+  ## XXX: HACK
+  const pt = 20.0
+  result = TextExtent(
+    x_bearing: 0.0,
+    y_bearing: 0.0,
+    width: pt * text.len.float,
+    height: pt)
+  result.x_advance = result.width
+  result.y_advance = result.height
+
+proc drawText*(img: var BImage, text: string, font: Font, at: Point,
+               alignKind: TextAlignKind = taLeft,
+               rotate: Option[float] = none[float](),
+               rotateInView: Option[(float, Point)] = none[(float, Point)]()) =
+  let atStr = at.toStr
+  latexAdd:
+    \node " at " `atStr` {`text`} ";"
+
+proc drawRectangle*(img: var BImage, left, bottom, width, height: float,
+                    style: Style,
+                    rotate: Option[float] = none[float](),
+                    rotateInView: Option[(float, Point),] = none[(float, Point)]()) =
+  let atStr = (x: left, y: bottom).toStr
+  let sizeStr = (x: width, y: height).toStr
+  latexAdd:
+    \draw " " `atStr` " " rectangle " " `sizeStr` ";"
+
+proc drawRaster*(img: var BImage, left, bottom, width, height: float,
+                 numX, numY: int,
+                 drawCb: proc(): seq[uint32],
+                 rotate: Option[float] = none[float](),
+                 rotateInView: Option[(float, Point),] = none[(float, Point)]()) =
+  debugecho "WARNING: `drawRaster` of TikZ backend is not implemented yet!"
+
+proc initBImage*(filename: string,
+                 width, height: int,
+                 fType: FiletypeKind): BImage =
+
+  result = BImage(fname: filename,
+                  backend: bkTikZ,
+                  width: width, height: height,
+                  fType: fType)

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -107,17 +107,16 @@ proc drawLine*(img: var BImage, start, stop: Point,
   let lineSt = style.lineStyle
   latexAdd:
     `color`
-    \draw " " `lineSt` " " `p0` " " -- " " `p1` ";"
+    \draw `lineSt` `p0` -- `p1` ";"
 
 proc drawPolyLine*(img: var BImage, points: seq[Point],
                    style: Style,
                    rotateAngle: Option[(float, Point)] = none[(float, Point)]()) =
   let lineSt = style.lineStyle
   let color = style.colorStr
-  echo lineSt
   latexAdd:
     `color`
-    \draw " " `lineSt`
+    \draw `lineSt`
   for i, p in points:
     let pStr = img.toStr(p)
     if i == points.high:
@@ -142,7 +141,7 @@ proc drawCircle*(img: var BImage, center: Point, radius: float,
   let lineSt = style.lineStyle
   latexAdd:
     `color`
-    \draw " " `lineSt` " " `p` " " circle " " [radius = `radius`] ";"
+    \draw `lineSt` `p` circle [radius = `radius`] ";"
 
 proc getTextExtent*(text: string, font: Font): TextExtent =
   ## XXX: HACK
@@ -178,20 +177,17 @@ proc drawText*(img: var BImage, text: string, font: Font, at: Point,
     discard
   else: discard
 
-  let at = (x: x, y: y)
-  let atStr = img.toStr(at)
-  let alignStr = img.nodeProperties(at, alignKind, rotate)
-  echo "ext at ", atStr, " with ", alignStr, " of ", text, " from ", at
-  let ts = $(font.size)
-  let tst = $((font.size) * 1.2)
-  var text = latex:
-    \fontsize{`ts`}{`tst`}\selectfont " " `text`
-  #if rotate.isSome:
-  #  let rt = $(-rotate.get)
-  #  text = latex:
-  #    \rotatebox{`rt`}{`text`}
+  let alignStr = img.nodeProperties((x: x, y: y), alignKind, rotate)
+  let fs = font.size
+  var textStr: string
+  if font.bold:
+    textStr = latex:
+      \fontsize{$(fs)}{$(fs * 1.2)}\selectfont {\textbf{`text`}}
+  else:
+    textStr = latex:
+      \fontsize{$(fs)}{$(fs * 1.2)}\selectfont `text`
   latexAdd:
-    \node " " `alignStr` " at " `atStr` {`text`} ";"
+    \node `alignStr` at $(img.toStr(at)) {`textStr`} ";"
 
 proc drawRectangle*(img: var BImage, left, bottom, width, height: float,
                     style: Style,
@@ -215,7 +211,7 @@ proc drawRectangle*(img: var BImage, left, bottom, width, height: float,
       let curLineStyle = style.lineStyle(fillColor = n)
       latexAdd:
         `curColor`
-        \draw " " `curLineStyle` " " `atStr` " " rectangle " " `sizeStr` ";"
+        \draw `curLineStyle` `atStr` rectangle `sizeStr` ";"
       curBottom += sliceHeight
   else:
     let color = style.colorStr
@@ -224,7 +220,7 @@ proc drawRectangle*(img: var BImage, left, bottom, width, height: float,
     let atStr = atPt.toStrDirect
     latexAdd:
       `color`
-      \draw " " `lineSt` " " `atStr` " " rectangle " " `sizeStr` ";"
+      \draw `lineSt` `atStr` rectangle `sizeStr` ";"
 
 proc drawRaster*(img: var BImage, left, bottom, width, height: float,
                  numX, numY: int,

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -30,19 +30,23 @@ func toStrDirect(p: Point, isLength: static bool = false): string =
     tmp
 
 proc toStr(alignKind: TextAlignKind): string =
-  ## convert the text align kind to the correct tikz notation
+  ## convert the text align kind to the correct TikZ notation.
+  ##
+  ## In TikZ the the node is placed `right`, `left` (etc.) of the coordinate, wherease
+  ## in cairo it is aligned by the `left` / `right` edge. Thus, the inversion.
   case alignKind
   of taLeft: result = "right"
   of taCenter: result = "" # default
   of taRight: result = "left"
 
 proc nodeProperties(img: BImage, at: Point, alignKind: TextAlignKind, rotate: Option[float]): string =
-  result = "["
-  result.add alignKind.toStr
+  result = alignKind.toStr
+  var rot: string
   if rotate.isSome:
-    #result.add ", rotate around = {" & $(-rotate.get) & ":" & at.toStr & "}" # rotation opposite of cairo
-    result.add ", rotate = " & $(-rotate.get) # rotation opposite of cairo
-  result.add "]"
+    rot = "rotate = " & $(-rotate.get) # rotation is opposite of cairo
+    result = if result.len > 0: result & ", " & rot else: rot
+  if result.len > 0:
+    result = "[" & result & "]"
   echo result
 
 template latexAdd(body: untyped): untyped {.dirty.} =

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -10,37 +10,83 @@ Maybe we have to collect all colors in a table or seq and create a custom 'pream
 contains color definitons?
 ]#
 
-template toStr(p: Point): string {.dirty.} =
+proc toTikZCoord(img: BImage, p: Point, isLength: static bool = false): Point =
+  let ratio = img.height.float / img.width.float
+  when isLength:
+    result = (x: p.x / img.width.float, y: p.y / img.height.float)
+  else:
+    result = (x: p.x / img.width.float, y: (img.height.float - p.y) / img.height.float)
+  result.y = result.y * ratio
+
+func toStr(img: BImage, p: Point, isLength: static bool = false): string =
   block:
-    let pst = (x: p.x / img.width.float, y: (img.height.float - p.y) / img.height.float)
-    &"({pst.x}\\textwidth, {pst.y}\\textwidth)"
+    let pst = img.toTikZCoord(p, isLength = isLength)
+    var tmp = &"({pst.x}\\textwidth, {pst.y}\\textwidth)"
+    tmp
+
+func toStrDirect(p: Point, isLength: static bool = false): string =
+  block:
+    var tmp = &"({p.x}\\textwidth, {p.y}\\textwidth)"
+    tmp
+
+proc toStr(alignKind: TextAlignKind): string =
+  ## convert the text align kind to the correct tikz notation
+  case alignKind
+  of taLeft: result = "right"
+  of taCenter: result = "" # default
+  of taRight: result = "left"
+
+proc nodeProperties(img: BImage, at: Point, alignKind: TextAlignKind, rotate: Option[float]): string =
+  result = "["
+  result.add alignKind.toStr
+  if rotate.isSome:
+    #result.add ", rotate around = {" & $(-rotate.get) & ":" & at.toStr & "}" # rotation opposite of cairo
+    result.add ", rotate = " & $(-rotate.get) # rotation opposite of cairo
+  result.add "]"
+  echo result
 
 template latexAdd(body: untyped): untyped {.dirty.} =
   let toAdd = latex:
     body
   img.data.add toAdd
 
+proc defColor(name: string, c: Color): string =
+  let color = &"{c.r * 256.0}, {c.g * 256.0}, {c.b * 256.0}"
+  result = latex:
+    \definecolor{`name`}{RGB}{`color`}
+
+proc colorStr(style: Style): string =
+  result.add defColor("drawColor", style.color)
+  result.add defColor("fillColor", style.fillColor)
+
+proc lineStyle(style: Style, drawColor = "drawColor", fillColor = "fillColor"): string =
+  #let color = "{" & &"{style.color.r * 256.0}, {style.color.g * 256.0}, {style.color.b * 256.0}" & "}"
+  let fillOp = &"fill opacity = {style.fillColor.a}"
+  let colorOp = &"draw opacity = {style.color.a}"
+  result = &"[color = {drawColor}, fill = {fillColor}, {colorOp}, {fillOp}, line width = {style.lineWidth}pt]"
+
 proc drawLine*(img: var BImage, start, stop: Point,
                style: Style,
                rotateAngle: Option[(float, Point)] = none[(float, Point)]()) =
-  let p0 = start.toStr
-  let p1 = stop.toStr
-  let colors = &"{style.color.r}, {style.color.g}, {style.color.b}" # , {style.color.a}
-  let color = latex:
-    \definecolor{foocolor}{RGB}{`colors`}
-  let lineWidth = &"[line width = {style.lineWidth}pt, fill = foocolor]"
-  #,fill={rgb:red,4;green,2;yellow,1}
+  let p0 = img.toStr(start)
+  let p1 = img.toStr(stop)
+  let color = style.colorStr
+  let lineSt = style.lineStyle
   latexAdd:
     `color`
-    \draw " " `lineWidth` " " `p0` " " -- " " `p1` ";"
+    \draw " " `lineSt` " " `p0` " " -- " " `p1` ";"
 
 proc drawPolyLine*(img: var BImage, points: seq[Point],
                    style: Style,
                    rotateAngle: Option[(float, Point)] = none[(float, Point)]()) =
+  let lineSt = style.lineStyle
+  let color = style.colorStr
+  echo lineSt
   latexAdd:
-    \draw
+    `color`
+    \draw " " `lineSt`
   for i, p in points:
-    let pStr = p.toStr
+    let pStr = img.toStr(p)
     if i == points.high:
       latexAdd:
         `pStr`
@@ -54,18 +100,26 @@ proc drawCircle*(img: var BImage, center: Point, radius: float,
                  strokeColor = color(0.0, 0.0, 0.0),
                  fillColor = color(0.0, 0.0, 0.0, 0.0),
                  rotateAngle: Option[(float, Point)] = none[(float, Point)]()) =
-  let p = center.toStr
+  let p = img.toStr(center)
+  let radius = $(radius / img.width.float) & "\\textwidth"# / img.width.float
+  let style = Style(lineWidth: lineWidth,
+                    color: strokeColor,
+                    fillColor: fillColor)
+  let color = style.colorStr
+  let lineSt = style.lineStyle
   latexAdd:
-    \draw " " `p` " " circle " " [radius = `radius`] ";"
+    `color`
+    \draw " " `lineSt` " " `p` " " circle " " [radius = `radius`] ";"
 
 proc getTextExtent*(text: string, font: Font): TextExtent =
   ## XXX: HACK
-  const pt = 20.0
+  let ptY = font.size
+  let ptX = ptY
   result = TextExtent(
     x_bearing: 0.0,
     y_bearing: 0.0,
-    width: pt * text.len.float,
-    height: pt)
+    width: ptX * text.len.float,
+    height: ptY)
   result.x_advance = result.width
   result.y_advance = result.height
 
@@ -73,18 +127,71 @@ proc drawText*(img: var BImage, text: string, font: Font, at: Point,
                alignKind: TextAlignKind = taLeft,
                rotate: Option[float] = none[float](),
                rotateInView: Option[(float, Point)] = none[(float, Point)]()) =
-  let atStr = at.toStr
+  ## TODO: fix this coord mess
+  var
+    x = at.x
+    y = at.y
+
+  let extents = getTextExtent("M", font)
+  # potentially rotate around specific point (location depends on where we align)
+  case alignKind
+  of taLeft:
+    x = at.x - (extents.width / 2.0 + extents.x_bearing)
+  of taRight:
+    x = at.x + (extents.width / 2.0 + extents.x_bearing)
+  of taCenter:
+    #x = at.x - (extents.width / 2.0 + extents.x_bearing)
+    #y = at.y + (extents.height / 2.0 + extents.y_bearing)
+    discard
+  else: discard
+
+  let at = (x: x, y: y)
+  let atStr = img.toStr(at)
+  let alignStr = img.nodeProperties(at, alignKind, rotate)
+  echo "ext at ", atStr, " with ", alignStr, " of ", text, " from ", at
+  let ts = $(font.size)
+  let tst = $((font.size) * 1.2)
+  var text = latex:
+    \fontsize{`ts`}{`tst`}\selectfont " " `text`
+  #if rotate.isSome:
+  #  let rt = $(-rotate.get)
+  #  text = latex:
+  #    \rotatebox{`rt`}{`text`}
   latexAdd:
-    \node " at " `atStr` {`text`} ";"
+    \node " " `alignStr` " at " `atStr` {`text`} ";"
 
 proc drawRectangle*(img: var BImage, left, bottom, width, height: float,
                     style: Style,
                     rotate: Option[float] = none[float](),
                     rotateInView: Option[(float, Point),] = none[(float, Point)]()) =
-  let atStr = (x: left, y: bottom).toStr
-  let sizeStr = (x: width, y: height).toStr
-  latexAdd:
-    \draw " " `atStr` " " rectangle " " `sizeStr` ";"
+  let atPt = img.toTikZCoord((x: left, y: bottom))
+  let sizePt = img.toTikZCoord((x: left + width, y: bottom + height), isLength = false)
+  if style.gradient.isSome:
+    let gradient = style.gradient.get
+    let heightRel = height / img.width.float
+    let sliceHeight = heightRel / (gradient.colors.len.float - 1)
+    var curBottom = atPt.y - heightRel
+    for i, c in gradient.colors:
+      let n = "color" & $i
+      let atStr = (x: atPt.x, y: curBottom).toStrDirect # left bottom coords
+      let sizeStr = (
+        x: sizePt.x,
+        y: curBottom + sliceHeight + 1e-3               # add some ε for overlap
+      ).toStrDirect                                     # end coords
+      let curColor = defColor(n, c)
+      let curLineStyle = style.lineStyle(fillColor = n)
+      latexAdd:
+        `curColor`
+        \draw " " `curLineStyle` " " `atStr` " " rectangle " " `sizeStr` ";"
+      curBottom += sliceHeight
+  else:
+    let color = style.colorStr
+    let lineSt = style.lineStyle
+    let sizeStr = sizePt.toStrDirect
+    let atStr = atPt.toStrDirect
+    latexAdd:
+      `color`
+      \draw " " `lineSt` " " `atStr` " " rectangle " " `sizeStr` ";"
 
 proc drawRaster*(img: var BImage, left, bottom, width, height: float,
                  numX, numY: int,

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -159,23 +159,17 @@ proc drawText*(img: var BImage, text: string, font: Font, at: Point,
                alignKind: TextAlignKind = taLeft,
                rotate: Option[float] = none[float](),
                rotateInView: Option[(float, Point)] = none[(float, Point)]()) =
-  ## TODO: fix this coord mess
   var
     x = at.x
     y = at.y
-
   let extents = getTextExtent("M", font)
-  # potentially rotate around specific point (location depends on where we align)
+  # `left`/`right` of node in TeX is too close. Add half a M letter spacing
   case alignKind
   of taLeft:
     x = at.x - (extents.width / 2.0 + extents.x_bearing)
   of taRight:
     x = at.x + (extents.width / 2.0 + extents.x_bearing)
-  of taCenter:
-    #x = at.x - (extents.width / 2.0 + extents.x_bearing)
-    #y = at.y + (extents.height / 2.0 + extents.y_bearing)
-    discard
-  else: discard
+  of taCenter: discard
 
   let alignStr = img.nodeProperties((x: x, y: y), alignKind, rotate)
   let fs = font.size

--- a/src/ginger/backends.nim
+++ b/src/ginger/backends.nim
@@ -1,6 +1,7 @@
 import chroma
 import types
 import options
+from os import getTempDir
 
 export types
 export chroma
@@ -80,6 +81,12 @@ when not defined(noCairo):
       )
     else: discard
 
+  # forward declarations to use them in `drawRaster` for `TikZ`
+  proc initBImage*(filename: string,
+                   width, height: int,
+                   fType: FiletypeKind,
+                   texOptions: TeXOptions): BImage
+  proc destroy*(img: var BImage)
   proc drawRaster*(img: var BImage, left, bottom, width, height: float,
                    numX, numY: int,
                    drawCb: proc(): seq[uint32],
@@ -91,8 +98,15 @@ when not defined(noCairo):
         img, left, bottom, width, height, numX, numY, drawCB, rotate, rotateInView
       )
     of bkTikz:
+      let tmpName = getTempDir() & "raster_ggplotnim_tikz_tmp_store.png"
+      var imgC = initBImage(tmpName,
+                            width = width.int, height = height.int,
+                            ftype = fkPng,
+                            texOptions = TeXOptions())
+      imgC.drawRaster(0, 0, width, height, numX, numY, drawCB, rotate, rotateInView)
+      imgC.destroy()
       backendTikz.drawRaster(
-        img, left, bottom, width, height, numX, numY, drawCB, rotate, rotateInView
+        img, tmpName, left, bottom, width, height, numX, numY, drawCB, rotate, rotateInView
       )
     else: discard
 

--- a/src/ginger/backends.nim
+++ b/src/ginger/backends.nim
@@ -1,26 +1,146 @@
 import chroma
 import types
+import options
 
 export types
 export chroma
 
 
 when not defined(noCairo):
-  import cairo
-  import backendCairo
-  export backendCairo
+  # import nothing into scope, so that we avoid overload ambiguity
+  from cairo import nil
+  from backendCairo import nil
+  from backendTikZ import nil
+
+  proc drawLine*(img: var BImage, start, stop: Point,
+                 style: Style,
+                 rotateAngle: Option[(float, Point)] = none[(float, Point)]()) =
+    case img.backend
+    of bkCairo: backendCairo.drawLine(img, start, stop, style, rotateAngle)
+    of bkTikZ: backendTikz.drawLine(img, start, stop, style, rotateAngle)
+    else: discard
+
+  proc drawPolyLine*(img: var BImage, points: seq[Point],
+                     style: Style,
+                     rotateAngle: Option[(float, Point)] = none[(float, Point)]()) =
+    case img.backend
+    of bkCairo: backendCairo.drawPolyLine(img, points, style, rotateAngle)
+    of bkTikZ: backendTikz.drawPolyLine(img, points, style, rotateAngle)
+    else: discard
+
+  proc drawCircle*(img: var BImage, center: Point, radius: float,
+                   lineWidth: float,
+                   strokeColor = color(0.0, 0.0, 0.0),
+                   fillColor = color(0.0, 0.0, 0.0, 0.0),
+                   rotateAngle: Option[(float, Point)] = none[(float, Point)]()) =
+    case img.backend
+    of bkCairo:
+      backendCairo.drawCircle(
+        img, center, radius, lineWidth, strokeColor, fillColor, rotateAngle
+      )
+    of bkTikz:
+      backendTikz.drawCircle(
+        img, center, radius, lineWidth, strokeColor, fillColor, rotateAngle
+      )
+    else: discard
+
+  proc getTextExtent*(text: string, font: Font): TextExtent =
+    #case img.backend
+    #of bkCairo: backendCairo.getTextExtent(text, font)
+    #of bkTikZ: backendTikZ.getTextExtent(text, font)
+    #else: discard
+    backendTikZ.getTextExtent(text, font)
+
+  proc drawText*(img: var BImage, text: string, font: Font, at: Point,
+                 alignKind: TextAlignKind = taLeft,
+                 rotate: Option[float] = none[float](),
+                 rotateInView: Option[(float, Point)] = none[(float, Point)]()) =
+    case img.backend
+    of bkCairo:
+      backendCairo.drawText(
+        img, text, font, at, alignKind, rotate, rotateInView
+      )
+    of bkTikz:
+      backendTikz.drawText(
+        img, text, font, at, alignKind, rotate, rotateInView
+      )
+    else: discard
+
+  proc drawRectangle*(img: var BImage, left, bottom, width, height: float,
+                      style: Style,
+                      rotate: Option[float] = none[float](),
+                      rotateInView: Option[(float, Point),] = none[(float, Point)]()) =
+    case img.backend
+    of bkCairo:
+      backendCairo.drawRectangle(
+        img, left, bottom, width, height, style, rotate, rotateInView
+      )
+    of bkTikz:
+      backendTikz.drawRectangle(
+        img, left, bottom, width, height, style, rotate, rotateInView
+      )
+    else: discard
+
+  proc drawRaster*(img: var BImage, left, bottom, width, height: float,
+                   numX, numY: int,
+                   drawCb: proc(): seq[uint32],
+                   rotate: Option[float] = none[float](),
+                   rotateInView: Option[(float, Point),] = none[(float, Point)]()) =
+    case img.backend
+    of bkCairo:
+      backendCairo.drawRaster(
+        img, left, bottom, width, height, numX, numY, drawCB, rotate, rotateInView
+      )
+    of bkTikz:
+      backendTikz.drawRaster(
+        img, left, bottom, width, height, numX, numY, drawCB, rotate, rotateInView
+      )
+    else: discard
+
+  proc initBImage*(filename: string,
+                   backend: BackendKind,
+                   width, height: int,
+                   fType: FiletypeKind): BImage =
+    case backend
+    of bkCairo:
+      result = backendCairo.initBImage(
+        filename, width, height, fType
+      )
+    of bkTikz:
+      result = backendTikz.initBImage(
+        filename, width, height, fType
+      )
+    else: discard
 
   proc destroy*(img: var BImage) =
     case img.backend
     of bkCairo:
       case img.fType
       of fkPng:
-        let err = img.cCanvas.write_to_png(img.fname)
+        let err = cairo.write_to_png(img.cCanvas, img.fname)
         echo err, " output of write_to_png"
       else: discard # not needed for SVG, PDF
       if img.created:
-        img.ctx.destroy()
-      img.cCanvas.destroy()
+        cairo.destroy(img.ctx)
+      cairo.destroy(img.cCanvas)
+    of bkTikZ:
+      # write to file
+      var f = open(img.fname, fmWrite)
+      f.write("""
+\documentclass[a4paper]{article}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{graphicx}
+\usepackage{tikz}
+\usepackage{siunitx}
+
+\begin{document}
+
+\begin{tikzpicture}
+  """)
+      f.write(img.data)
+      f.write("\n" & r"\end{tikzpicture}" & "\n" & r"\end{document}")
+      f.close()
     of bkVega:
       discard
 else:
@@ -33,8 +153,8 @@ else:
 when isMainModule:
   # backend layer cairo code
   var img = initBImage("test.svg",
-                       width = 600, height = 400,
                        backend = bkCairo,
+                       width = 600, height = 400,
                        ftype = fkSvg)
   img.drawLine((0.0, 0.0), (150.0, 140.0))
   img.drawCircle((200.0, 300.0), 2.0, lineWidth = 1.0,

--- a/src/ginger/backends.nim
+++ b/src/ginger/backends.nim
@@ -46,10 +46,10 @@ when not defined(noCairo):
       )
     else: discard
 
-  proc getTextExtent*(text: string, font: Font): TextExtent =
-    case img.backend
-    of bkCairo: backendCairo.getTextExtent(text, font)
-    of bkTikZ: backendTikZ.getTextExtent(text, font)
+  proc getTextExtent*(backend: BackendKind, text: string, font: Font): TextExtent =
+    case backend
+    of bkCairo: result = backendCairo.getTextExtent(text, font)
+    of bkTikZ: result = backendTikZ.getTextExtent(text, font)
     else: discard
 
   proc drawText*(img: var BImage, text: string, font: Font, at: Point,

--- a/src/ginger/backends.nim
+++ b/src/ginger/backends.nim
@@ -128,18 +128,28 @@ when not defined(noCairo):
       var f = open(img.fname, fmWrite)
       f.write("""
 \documentclass[a4paper]{article}
+% \documentclass[tikz,border = 2mm]{standalone}
 \usepackage[utf8]{inputenc}
+\usepackage[margin=2.5cm]{geometry}
+\usepackage[rgb]{xcolor}
 \usepackage[T1]{fontenc}
+\usepackage{unicode-math}
+\usepackage{amsmath}
 \usepackage{graphicx}
 \usepackage{tikz}
 \usepackage{siunitx}
 
 \begin{document}
 
+\begin{center}
 \begin{tikzpicture}
   """)
       f.write(img.data)
-      f.write("\n" & r"\end{tikzpicture}" & "\n" & r"\end{document}")
+      f.write("""
+\end{tikzpicture}
+\end{center}
+\end{document}
+""")
       f.close()
     of bkVega:
       discard

--- a/src/ginger/backends.nim
+++ b/src/ginger/backends.nim
@@ -45,11 +45,10 @@ when not defined(noCairo):
     else: discard
 
   proc getTextExtent*(text: string, font: Font): TextExtent =
-    #case img.backend
-    #of bkCairo: backendCairo.getTextExtent(text, font)
-    #of bkTikZ: backendTikZ.getTextExtent(text, font)
-    #else: discard
-    backendTikZ.getTextExtent(text, font)
+    case img.backend
+    of bkCairo: backendCairo.getTextExtent(text, font)
+    of bkTikZ: backendTikZ.getTextExtent(text, font)
+    else: discard
 
   proc drawText*(img: var BImage, text: string, font: Font, at: Point,
                  alignKind: TextAlignKind = taLeft,

--- a/src/ginger/types.nim
+++ b/src/ginger/types.nim
@@ -37,6 +37,12 @@ type
   AxisKind* = enum
     akX, akY
 
+  TeXOptions* = object
+    useTeX*: bool                # arguments only used if true
+    texTemplate*: Option[string] # a custom user TeX template
+    standalone*: bool            # if true output to a standalone TeX document
+    onlyTikZ*: bool              # if true write ``only`` TikZ commands to file
+
   BImage* = object
     fname*: string
     width*: int
@@ -49,6 +55,7 @@ type
       created*: bool # if surface was created
     of bkTikZ:
       data*: string # stores the TikZ commands as a string to be inserted into a LaTeX template
+      options*: TexOptions
     of bkVega: discard
 
   LineType* = enum

--- a/src/ginger/types.nim
+++ b/src/ginger/types.nim
@@ -27,9 +27,9 @@ else:
 
 type
   BackendKind* = enum
-    bkCairo, bkVega
+    bkCairo, bkVega, bkTikZ
   FiletypeKind* = enum
-    fkSvg, fkPng, fkPdf, fkVega
+    fkSvg, fkPng, fkPdf, fkVega, fkTeX
 
   Point* = tuple[x, y: float]
   IPoint* = tuple[x, y: int]
@@ -41,14 +41,15 @@ type
     fname*: string
     width*: int
     height*: int
+    ftype*: FileTypeKind
     case backend*: BackendKind
     of bkCairo:
       cCanvas*: PSurface
       ctx*: PContext
       created*: bool # if surface was created
-      ftype*: FileTypeKind
-    of bkVega:
-      discard
+    of bkTikZ:
+      data*: string # stores the TikZ commands as a string to be inserted into a LaTeX template
+    of bkVega: discard
 
   LineType* = enum
     ltNone, ltSolid, ltDashed, ltDotted, ltDotDash, ltLongDash, ltTwoDash


### PR DESCRIPTION
Finally adds the TikZ backend for ginger, so that we can directly generate TeX code for plots.

Still some things missing:
- [x] raster plots (by producing bitmap that is embedded maybe?)
- [ ] text extents is currently a hack. Might stay a hack. The problem is we'd have to start a TeX compiler to get that information, which is crazy. Ideally we make the ginger math computations lazy so that we can emit relative coordinates + string based ones into the TeX file.
- [ ] text sizes are larger by default ~~, leading to some not so amazing spacing~~. It's not actually a real problem. The issues were elsewhere.
- [x] line styles missing