### PR TITLE
Fix dummy backend

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,6 @@
+* v0.3.2
+- have =initBImage= take a default =TeXOptions()= argument
+- fix dummy backend to be inline with normal API  
 * v0.3.1
 - update LatexDSL dependency to version =v0.1.5=
 * v0.3.0

--- a/src/ginger/backendDummy.nim
+++ b/src/ginger/backendDummy.nim
@@ -20,7 +20,7 @@ proc drawCircle*(img: BImage, center: Point, radius: float,
                  rotateAngle: Option[(float, Point)] = none[(float, Point)]()) =
   debugecho "WARNING: `drawCircle` of dummy backend is being called!"
 
-proc getTextExtent*(text: string, font: Font): TextExtent =
+proc getTextExtent*(backend: BackendKind, text: string, font: Font): TextExtent =
   debugecho "WARNING: `getTextExtent` of dummy backend is being called!"
 
 proc drawText*(img: BImage, text: string, font: Font, at: Point,
@@ -42,8 +42,9 @@ proc drawRaster*(img: var BImage, left, bottom, width, height: float,
                  rotateInView: Option[(float, Point),] = none[(float, Point)]()) =
   debugecho "WARNING: `drawRaster` of dummy backend is being called!"
 
+
 proc initBImage*(filename: string,
                  width, height: int,
-                 backend: BackendKind,
-                 fType: FiletypeKind): BImage =
+                 fType: FiletypeKind,
+                 texOptions: TeXOptions): BImage =
   debugecho "WARNING: `initBImage` of dummy backend is being called!"

--- a/src/ginger/backends.nim
+++ b/src/ginger/backends.nim
@@ -114,7 +114,7 @@ when not defined(noCairo):
   proc initBImage*(filename: string,
                    width, height: int,
                    fType: FiletypeKind,
-                   texOptions: TeXOptions): BImage =
+                   texOptions = TeXOptions()): BImage =
     let backend = if ftype == fkTeX or (ftype == fkPdf and texOptions.useTeX): bkTikZ
                   else: bkCairo
     case backend


### PR DESCRIPTION
Fixes the dummy backend to be in line with our current API and gives `initBImage` a default value for `TeXOptions`.