### PR TITLE
More TikZ fixes and backend determination refactor

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,7 @@
+* v0.3.4
+- TikZ fixes for text placement and multi line text
+- merge determination of backend into single =toBackend= procedure
+- export =parseFilename=, which returns =FileTypeKind= from filename
 * v0.3.3
 - fix determination of platform in =backends.nim= for OSX
 - fail at CT if a bad platform is encountered for TikZ + PDF generation  

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -3134,6 +3134,20 @@ proc parseFilename*(fname: string): FiletypeKind =
   else:
     result = fkPdf
 
+proc toBackend*(fType: FiletypeKind, texOptions: TexOptions): BackendKind =
+  ## TODO: generalize the `texOptions` to variant object for possible other backends
+  case fType
+  of fkSvg: result = bkCairo
+  of fkPng: result = bkCairo
+  of fkTeX: result = bkTikZ
+  of fkPdf:
+    # depends on `texOptions`
+    result = if texOptions.useTeX or texOptions.texTemplate.isSome:
+               bkTikZ
+             else:
+               bkCairo # extend for Pixie
+  of fkVega: doAssert false # not supported
+
 proc draw*(img: var BImage, gobj: GraphObject) =
   ## draws the given graph object on the image
   let globalObj = gobj.toGlobalCoords(img)
@@ -3206,10 +3220,12 @@ when not defined(noCairo):
   proc draw*(view: Viewport, filename: string, texOptions: TeXOptions = TeXOptions()) =
     ## draws the given viewport and all its children and stores it in the
     ## file `filename`
-    let ftype = parseFilename(filename)
+    let fType = parseFilename(filename)
+    let backend = fType.toBackend(texOptions)
     var img = initBImage(filename,
                          width = view.wImg.val.round.int, height = view.hImg.val.round.int,
-                         ftype = ftype,
+                         backend = backend,
+                         ftype = fType,
                          texOptions = texOptions)
     img.draw(view)
     img.destroy()

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -1886,7 +1886,7 @@ proc initMultiLineText*(view: Viewport,
   ## hardcoded, since this works for now.
   assert textKind in {goText, goLabel, goTickLabel}
   let font = if fontOpt.isSome: fontOpt.unsafeGet else: defaultFont()
-  let lines = text.splitLines
+  let lines = text.splitLines # TODO: extend to allow detection of latex `\\`?
   let totalHeight = getStrHeight(view.backend, text, font)
   let numLines = lines.len
   for idx, line in lines:

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -3120,7 +3120,7 @@ proc getCenter*(view: Viewport): (float, float) =
       height(view).toRelative(length = some(pointHeight(view))).val / 2.0
   result = (centerX, centerY)
 
-proc parseFilename(fname: string): FiletypeKind =
+proc parseFilename*(fname: string): FiletypeKind =
   let (_, _, ext) = fname.splitFile
   case ext.normalize
   of ".pdf":

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -40,12 +40,22 @@ proc toStr(alignKind: TextAlignKind): string =
   of taCenter: result = "" # default
   of taRight: result = "left"
 
-proc nodeProperties(img: BImage, at: Point, alignKind: TextAlignKind, rotate: Option[float]): string =
-  result = alignKind.toStr
-  var rot: string
+proc nodeProperties(img: BImage, at: Point, alignKind: TextAlignKind, rotate: Option[float],
+                    font: Font,
+                    alignLeft = false): string =
+  var res = newSeq[string]()
+  let ak = alignKind.toStr
+  if ak.len > 0:
+    res.add ak
   if rotate.isSome:
-    rot = "rotate = " & $(-rotate.get) # rotation is opposite of cairo
-    result = if result.len > 0: result & ", " & rot else: rot
+    res.add "rotate = " & $(-rotate.get) # rotation is opposite of cairo
+  let fs = font.size
+  let fontSize = latex:
+    font = \fontsize{$(fs)}{$(fs * 1.2)}\selectfont
+  res.add fontSize
+  if alignLeft:
+    res.add "align=left"
+  result = res.join(", ")
   if result.len > 0:
     result = "[" & result & "]"
   echo result

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -4,7 +4,7 @@ import types
 import options
 
 import os, latexdsl, strformat
-from strutils import `%`
+from strutils import `%`, join, contains
 
 #[
 Maybe we have to collect all colors in a table or seq and create a custom 'preamble' that
@@ -182,16 +182,17 @@ proc drawText*(img: var BImage, text: string, font: Font, at: Point,
     x = at.x + (extents.width / 2.0 + extents.x_bearing)
   of taCenter: discard
 
-  let alignStr = img.nodeProperties((x: x, y: y), alignKind, rotate)
-  let fs = font.size
+  let alignLeft = if r"\\" in text: true else: false # for manual line breaks, need left alignment
   let xAt = (x: x, y: y)
+  let alignStr = img.nodeProperties(xAt, alignKind, rotate, font,
+                                    alignLeft = alignLeft)
   var textStr: string
   if font.bold:
     textStr = latex:
-      \fontsize{$(fs)}{$(fs * 1.2)}\selectfont {\textbf{`text`}}
+      \textbf{`text`}
   else:
     textStr = latex:
-      \fontsize{$(fs)}{$(fs * 1.2)}\selectfont `text`
+      `text`
   latexAdd:
     \node `alignStr` at $(img.toStr(xAt)) {`textStr`} ";"
 

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -184,6 +184,7 @@ proc drawText*(img: var BImage, text: string, font: Font, at: Point,
 
   let alignStr = img.nodeProperties((x: x, y: y), alignKind, rotate)
   let fs = font.size
+  let xAt = (x: x, y: y)
   var textStr: string
   if font.bold:
     textStr = latex:
@@ -192,7 +193,7 @@ proc drawText*(img: var BImage, text: string, font: Font, at: Point,
     textStr = latex:
       \fontsize{$(fs)}{$(fs * 1.2)}\selectfont `text`
   latexAdd:
-    \node `alignStr` at $(img.toStr(at)) {`textStr`} ";"
+    \node `alignStr` at $(img.toStr(xAt)) {`textStr`} ";"
 
 proc drawRectangle*(img: var BImage, left, bottom, width, height: float,
                     style: Style,

--- a/src/ginger/backends.nim
+++ b/src/ginger/backends.nim
@@ -85,6 +85,7 @@ when not defined(noCairo):
   # forward declarations to use them in `drawRaster` for `TikZ`
   proc initBImage*(filename: string,
                    width, height: int,
+                   backend: BackendKind,
                    fType: FiletypeKind,
                    texOptions = TeXOptions()): BImage
   proc destroy*(img: var BImage)
@@ -102,6 +103,7 @@ when not defined(noCairo):
       let tmpName = getTempDir() & "raster_ggplotnim_tikz_tmp_store.png"
       var imgC = initBImage(tmpName,
                             width = width.int, height = height.int,
+                            backend = bkCairo,
                             ftype = fkPng,
                             texOptions = TeXOptions())
       imgC.drawRaster(0, 0, width, height, numX, numY, drawCB, rotate, rotateInView)
@@ -113,10 +115,9 @@ when not defined(noCairo):
 
   proc initBImage*(filename: string,
                    width, height: int,
+                   backend: BackendKind,
                    fType: FiletypeKind,
                    texOptions = TeXOptions()): BImage =
-    let backend = if ftype == fkTeX or (ftype == fkPdf and texOptions.useTeX): bkTikZ
-                  else: bkCairo
     case backend
     of bkCairo:
       result = backendCairo.initBImage(


### PR DESCRIPTION
Fixes some small issues with the TikZ backend (placement of text depending on alignment and multi line text) and adds a single `toBackend` procedure that returns the correct backend given a `FileTypeKind` and a `TexOptions` object (which soon may be extended to a general `BackendOptions` object).