### PR TITLE
Reduce TikZ file footprint

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,7 @@
+* v0.3.7
+- reduces the output size of plots on the TikZ backend, by reducing
+  printed precision of positions and avoiding multiple outputs of the
+  same color
 * v0.3.6
 - add options for TikZ backend to embed the plot in a full figure
   environment with a given caption and label

--- a/ginger.nimble
+++ b/ginger.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.6"
+version       = "0.3.7"
 author        = "Vindaar"
 description   = "A Grid (R) like package in Nim"
 license       = "MIT"

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -70,6 +70,12 @@ proc defColor(name: string, c: Color): string =
   result = latex:
     \definecolor{`name`}{rgb}{`color`}
 
+func addColorIfNew(img: var BImage, color: string) =
+  if color != img.lastColor:
+    latexAdd:
+      `color`
+    img.lastColor = color
+
 proc colorStr(style: Style): string =
   result.add defColor("drawColor", style.color)
   result.add defColor("fillColor", style.fillColor)
@@ -116,8 +122,8 @@ proc drawLine*(img: var BImage, start, stop: Point,
   let p1 = img.toStr(stop)
   let color = style.colorStr
   let lineSt = style.lineStyle
+  img.addColorIfNew(color)
   latexAdd:
-    `color`
     \draw `lineSt` `p0` -- `p1` ";"
 
 proc drawPolyLine*(img: var BImage, points: seq[Point],
@@ -125,8 +131,8 @@ proc drawPolyLine*(img: var BImage, points: seq[Point],
                    rotateAngle: Option[(float, Point)] = none[(float, Point)]()) =
   let lineSt = style.lineStyle
   let color = style.colorStr
+  img.addColorIfNew(color)
   latexAdd:
-    `color`
     \draw `lineSt`
   for i, p in points:
     let pStr = img.toStr(p)
@@ -149,9 +155,9 @@ proc drawCircle*(img: var BImage, center: Point, radius: float,
                     color: strokeColor,
                     fillColor: fillColor)
   let color = style.colorStr
+  img.addColorIfNew(color)
   let lineSt = style.lineStyle
   latexAdd:
-    `color`
     \draw `lineSt` `p` circle [radius = `radius`] ";"
 
 proc getTextExtent*(text: string, font: Font): TextExtent =
@@ -225,8 +231,8 @@ proc drawRectangle*(img: var BImage, left, bottom, width, height: float,
     let lineSt = style.lineStyle
     let sizeStr = sizePt.toStrDirect
     let atStr = atPt.toStrDirect
+    img.addColorIfNew(color)
     latexAdd:
-      `color`
       \draw `lineSt` `atStr` rectangle `sizeStr` ";"
 
 from backendCairo import nil

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -22,12 +22,12 @@ proc toTikZCoord(img: BImage, p: Point, isLength: static bool = false): Point =
 func toStr(img: BImage, p: Point, isLength: static bool = false): string =
   block:
     let pst = img.toTikZCoord(p, isLength = isLength)
-    var tmp = &"({pst.x}\\textwidth, {pst.y}\\textwidth)"
+    var tmp = &"({pst.x:.4f}\\textwidth, {pst.y:.4f}\\textwidth)"
     tmp
 
 func toStrDirect(p: Point, isLength: static bool = false): string =
   block:
-    var tmp = &"({p.x}\\textwidth, {p.y}\\textwidth)"
+    var tmp = &"({p.x:.4f}\\textwidth, {p.y:.4f}\\textwidth)"
     tmp
 
 proc toStr(alignKind: TextAlignKind): string =

--- a/src/ginger/types.nim
+++ b/src/ginger/types.nim
@@ -59,6 +59,7 @@ type
     of bkTikZ:
       data*: string # stores the TikZ commands as a string to be inserted into a LaTeX template
       options*: TexOptions
+      lastColor*: string # stores the last used color to avoid redefining same color
     of bkVega: discard
 
   LineType* = enum


### PR DESCRIPTION
This improves the output size of the generated TikZ (.tex) file, by getting rid of redundant information. There's more we could do here, these are just some of the low hanging fruit.

This is important, as compiling a reasonably large plot with `pdflatex` causes problems due to the memory usage and how much memory `pdflatex` allocates. This can be circumvented by using `lualatex` (due to dynamic memory management), but doesn't mean we should emit too much noise.