### PR TITLE
More alignment fixes

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,8 @@
+* v0.3.10
+- further fixes placement of tick labels to make sure x and y axes are
+  at the same distance from the ticks
+- hotfix for a regression in =v0.3.9=, which broke manual line breaks
+  in TikZ backend annotations
 * v0.3.9
 - add a =bkNone= backend kind to detect if no backend was set
   explicitly

--- a/ginger.nimble
+++ b/ginger.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.9"
+version       = "0.3.10"
 author        = "Vindaar"
 description   = "A Grid (R) like package in Nim"
 license       = "MIT"

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -2287,10 +2287,10 @@ proc ylabel*(view: Viewport,
 template xLabelOriginOffset(backend: BackendKind, fnt: Font, isSecondary = false): untyped =
   if not isSecondary:
     # uses `W` as default
-    strWidth(backend, -1.25, fnt)
+    strWidth(backend, -1.15, fnt)
       .toRelative(length = some(pointWidth(view)))
   else:
-    strWidth(backend, 1.25, fnt)
+    strWidth(backend, 1.15, fnt)
       .toRelative(length = some(pointWidth(view)))
 
 template yLabelOriginOffset(backend: BackendKind, fnt: Font, isSecondary = false): untyped =

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -193,22 +193,11 @@ proc drawText*(img: var BImage, text: string, font: Font, at: Point,
                alignKind: TextAlignKind = taLeft,
                rotate: Option[float] = none[float](),
                rotateInView: Option[(float, Point)] = none[(float, Point)]()) =
-  var
-    x = at.x
-    y = at.y
-  let extents = getTextExtent("M", font)
-  # `left`/`right` of node in TeX is too close. Add half a M letter spacing
-  case alignKind
-  of taLeft:
-    x = at.x - (extents.width / 2.0 + extents.x_bearing)
-  of taRight:
-    x = at.x + (extents.width / 2.0 + extents.x_bearing)
-  of taCenter: discard
-
   let alignLeft = if r"\\" in text: true else: false # for manual line breaks, need left alignment
-  let xAt = (x: x, y: y)
-  let alignStr = img.nodeProperties(xAt, alignKind, rotate, font,
-                                    alignLeft = alignLeft)
+  let useAlignOverAnchor = r"\\" in text
+  let alignStr = img.nodeProperties(at, alignKind, rotate, font,
+                                    alignLeft = alignLeft,
+                                    useAlignOverAnchor = useAlignOverAnchor)
   var textStr: string
   if font.bold:
     textStr = latex:
@@ -217,7 +206,7 @@ proc drawText*(img: var BImage, text: string, font: Font, at: Point,
     textStr = latex:
       `text`
   latexAdd:
-    \node `alignStr` at $(img.toStr(xAt)) {`textStr`} ";"
+    \node `alignStr` at $(img.toStr(at)) {`textStr`} ";"
 
 proc drawRectangle*(img: var BImage, left, bottom, width, height: float,
                     style: Style,

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -77,9 +77,10 @@ proc nodeProperties(img: BImage, at: Point, alignKind: TextAlignKind, rotate: Op
     result = "[" & result & "]"
 
 template latexAdd(body: untyped): untyped {.dirty.} =
-  let toAdd = latex:
-    body
-  img.data.add toAdd
+  block:
+    let toAdd = latex:
+      body
+    img.data.add toAdd
 
 proc defColor(name: string, c: Color): string =
   let color = &"{c.r}, {c.g}, {c.b}"


### PR DESCRIPTION
Fixes the placement of the y tick labels to be at the same distance as x tick labels. Also fixes a regression breaking multi line text annotations on TikZ backend.