### PR TITLE
`embedAsRelative`, new default backends, ...

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -6,11 +6,15 @@
     ~formatBiggestFloat~.
 - handle monospace font family in TikZ backend via ~\texttt~
 - change backends to default to Cairo + TikZ activated
-- add `embedAsRelative`, `toRelative` to convert Viewport to relative
+- add ~embedAsRelative~, ~toRelative~ to convert Viewport to relative
   Allows to embed a viewport using relative size, which makes it easier
   to merge a final plot into a viewport of different aspect ratio and
   size than expected, as the relative size will remain and not the
   absolute ones (if any).
+- fix a bug of drawing error bars in ~T~ style, which did not take
+  data scale correctly into account resulting in too large or too
+  small "side" bars.
+- add ~+~ and ~-~ between ~Coord1D~ and ~Quantity~ for the same kind
 * v0.4.0
 - make backends generic objects to allow to select different backends
   at compile time and to simplify code

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,16 @@
+* v0.4.1
+- adds two CT variables that can be adjusted (~{.intdefine.}~)
+  - ~TickPrecisionCutoff~: decimal of the ~10^((-)TickPrecisionCutoff)~ value within
+    which the tick labels are printed as decimal values and outside in exp notation
+  - ~TickPrecision~: the number of digits used as precision as an argument to
+    ~formatBiggestFloat~.
+- handle monospace font family in TikZ backend via ~\texttt~
+- change backends to default to Cairo + TikZ activated
+- add `embedAsRelative`, `toRelative` to convert Viewport to relative
+  Allows to embed a viewport using relative size, which makes it easier
+  to merge a final plot into a viewport of different aspect ratio and
+  size than expected, as the relative size will remain and not the
+  absolute ones (if any).
 * v0.4.0
 - make backends generic objects to allow to select different backends
   at compile time and to simplify code

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -226,7 +226,7 @@ proc toRelative*(q: Quantity,
     if scale.isSome:
       let sc = scale.unsafeGet
       # NOTE: we do ``not`` subtract the lower scale from `q.val`, because this is
-      # a ``quantity`` and not a ccoordinate!
+      # a ``quantity`` and not a coordinate!
       result = quant(q.val / (sc.high - sc.low), ukRelative)
     else:
       raise newException(Exception, "Need a scale to convert quantity of kind " &

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -2693,17 +2693,25 @@ proc layout*(view: Viewport,
       ## Margins are 2 times given margin in relative units relative to the width of a single
       ## viewport in the resulting layout!
       ## TODO: possibly given `colWidths`?
+      ## XXX: fix up the spacing so that first / last rows / columns have less spacing, e.g.
+      ## for a plot layout with facets, no need to leave more space on left of first plot.
+      ## Sadly not as simple as below commented out!
+      let factorW = 2.0#if j == 0 or j == (cols - 1): 1.0
+                    #else: 2.0
+      let factorH = 2.0#if i == 0 or i == (rows - 1): 1.0
+                    #else: 2.0
       let width = sub(widths[j],
-                      times(quant(2.0, ukRelative), marginX,
+                      times(quant(factorW, ukRelative), marginX,
                             length = some(quant(pointWidth(view).val / cols.float,
                                                 ukPoint)),
                             scale = some(view.xScale)),
                       length = some(pointWidth(view)),
                       scale = some(view.xScale))
-      let height = sub(heights[i], times(quant(2.0, ukRelative), marginY,
-                                         length = some(quant(pointHeight(view).val / rows.float,
-                                                             ukPoint)),
-                                         scale = some(view.yScale)),
+      let height = sub(heights[i],
+                       times(quant(factorH, ukRelative), marginY,
+                             length = some(quant(pointHeight(view).val / rows.float,
+                                                 ukPoint)),
+                             scale = some(view.yScale)),
                        length = some(pointHeight(view)),
                        scale = some(view.yScale))
       ## TODO: fix margin. Currently cannot work, since we do not apply the margin

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -1950,19 +1950,12 @@ proc initErrorBar*(view: Viewport,
                   x2 = errorDown,
                   y1 = pt.y,
                   y2 = pt.y)
-      ## NOTE: convert point size of error bar `T` into absolute scale
-      ## of the Y position. We do this, because otherwise we run into
-      ## a problem, as the result will be `ukRelative`, causing the lines
-      ## to be drawn inverted. Ref downstream:
-      ## https://github.com/Vindaar/ggplotnim/issues/94
-      ## This fixes the downstream bug, but I'm a bit unclear why it breaks.
-      ## Does `ukRelative` simply always refer to position from *top*? That
-      ## would of course be wrong for the y axis.
+      # convert size of `T` to size in data scale coordinates
       let sc = some(pt.y.scale)
-      let locAbs = view.c1(locStyle.size, akY, ukPoint)
+      let locAbs = quant(locStyle.size, ukPoint)
         .to(ukData,
-            datScale = sc,
-            datAxis = some(akY))
+            scale = sc,
+            length = some(view.pointHeight()))
       let pLow = pt.y - locAbs
       let pHigh = pt.y + locAbs
       let chRight = view.initLine(
@@ -1987,15 +1980,11 @@ proc initErrorBar*(view: Viewport,
                   y1 = errorUp,
                   y2 = errorDown)
       let sc = some(pt.x.scale)
-      ## Conversion to absolute (ukPoint) coordinates. For the same (equivalent)
-      ## reason as mentioned above. If an `xMargin` is added without this conversion,
-      ## the resulting error bar top lines (that make the 'T'), are shifted. End up
-      ## at the location in pixel coordinates that would be correct without a margin.
-      ## By converting here the placement is correct including a margin. Weird.
-      let locAbs = view.c1(locStyle.size, akX, ukPoint)
+      # convert size of `T` to size in data scale coordinates
+      let locAbs = quant(locStyle.size, ukPoint)
         .to(ukData,
-            datScale = sc,
-            datAxis = some(akX))
+            scale = sc,
+            length = some(view.pointWidth()))
       let pLeft = pt.x - locAbs
       let pRight = pt.x + locAbs
       let chUp = view.initLine(

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -901,6 +901,22 @@ proc `-`*(c1, c2: Coord1D): Coord1D =
       result = Coord1D(pos: c1.toRelative.pos - c2.toRelative.pos,
                        kind: ukRelative)
 
+proc `-`*(c: Coord1D, q: Quantity): Coord1D =
+  if c.kind == q.unit:
+    result = c
+    result.pos -= q.val
+  else:
+    raise newException(ValueError, "Subtraction of a quantity from a Coord1D currently " &
+      "only supported for the same quantity kind in each.")
+
+proc `+`*(c: Coord1D, q: Quantity): Coord1D =
+  if c.kind == q.unit:
+    result = c
+    result.pos += q.val
+  else:
+    raise newException(ValueError, "Subtraction of a quantity from a Coord1D currently " &
+      "only supported for the same quantity kind in each.")
+
 proc `*`*(c1, c2: Coord1D): Coord1D =
   ## subtracts two Coord1D by converting to relative coordinates if necessary.
   ## If both coordinates have the same kind and their potential scales

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -93,18 +93,27 @@ func formatTickValue*(f: float, scale = 0.0): string =
   ## the zero value on the scale. From e.g. `linspace` we might end up
   ## with `5.1234e-17` for the string representation of zero. The scale
   ## is required to know whether the values aren't inherently this small.
+  ##
+  ## The `{.intdefine.}` compile time constants `TickPrecisionCutoff` and `TickPrecision`
+  ## can be used to adjust the
+  ## - `TickPrecisionCutoff`: decimal of the `10^((-)TickPrecisionCutoff)` value within
+  ##   which the tick labels are printed as decimal values and outside in exp notation
+  ## - `TickPrecision`: the number of digits used as precision as an argument to
+  ##   `formatBiggestFloat`.
+  const TickPrecisionCutoff {.intdefine.} = 6
+  const TickPrecision {.intdefine.} = 5
   if abs(f) < scale / 10.0:
     # IMPORTANT: we make a big assumption here! Namely that our tick positions
     # are "reasonably" placed. If we find a value that's smaller than a
     # `1/10` of the scale it's probably supposed to be a `"0"`. For some weird
     # asymmetric tick posisionts this might actually be wrong!
     result = "0"
-  elif abs(f) >= 1e5 or abs(f) <= 1e-5:
+  elif abs(f) >= pow(10.0, TickPrecisionCutoff) or abs(f) <= pow(10.0, -(TickPrecisionCutoff)):
     result = f.formatBiggestFloat(format = ffScientific,
-                                  precision = 4)
+                                  precision = TickPrecision)
   else:
     result = f.formatBiggestFloat(format = ffDefault,
-                                  precision = 4)
+                                  precision = TickPrecision)
   result.trimZeros()
 
 #template XAxis2YPos*(view: Option[Viewport] = none[Viewport](),

--- a/src/ginger/backendCairo.nim
+++ b/src/ginger/backendCairo.nim
@@ -266,8 +266,8 @@ proc drawRaster*(img: var BImage[CairoBackend], left, bottom, width, height: flo
     let
       width = abs(width)
       height = abs(height)
-    let wImg = width.int32
-    let hImg = height.int32
+    let wImg = width.round.int32
+    let hImg = height.round.int32
     var pngSurface = imageSurfaceCreate(FORMAT_ARGB32, wImg, hImg)
 
     pngSurface.flush()

--- a/src/ginger/backendCairo.nim
+++ b/src/ginger/backendCairo.nim
@@ -266,8 +266,9 @@ proc drawRaster*(img: var BImage[CairoBackend], left, bottom, width, height: flo
     let
       width = abs(width)
       height = abs(height)
-    let wImg = width.round.int32
-    let hImg = height.round.int32
+    # we *truncate* the width / height here. Better one pixel short than too much
+    let wImg = width.floor.int32
+    let hImg = height.floor.int32
     var pngSurface = imageSurfaceCreate(FORMAT_ARGB32, wImg, hImg)
 
     pngSurface.flush()

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -207,6 +207,9 @@ proc drawText*(img: var BImage[TikZBackend], text: string, font: Font, at: Point
   if font.bold:
     textStr = latex:
       \textbf{`text`}
+  elif font.family == "monospace":
+    textStr = latex:
+      \texttt{`text`}
   else:
     textStr = latex:
       `text`

--- a/src/ginger/types.nim
+++ b/src/ginger/types.nim
@@ -3,8 +3,8 @@ import options
 
 ## CT variables adjustable via command line arguments (or nim.cfg / config.nims) to (de-)activate
 ## different backends
-const useCairo* {.booldefine.} = false
-const useTikZ* {.booldefine.}  = false
+const useCairo* {.booldefine.} = true
+const useTikZ* {.booldefine.}  = true
 const usePixie* {.booldefine.} = false
 
 type


### PR DESCRIPTION
Changelog:

```
* v0.4.1
- adds two CT variables that can be adjusted (~{.intdefine.}~)
  - ~TickPrecisionCutoff~: decimal of the ~10^((-)TickPrecisionCutoff)~ value within
    which the tick labels are printed as decimal values and outside in exp notation
  - ~TickPrecision~: the number of digits used as precision as an argument to
    ~formatBiggestFloat~.
- handle monospace font family in TikZ backend via ~\texttt~
- change backends to default to Cairo + TikZ activated
- add ~embedAsRelative~, ~toRelative~ to convert Viewport to relative
  Allows to embed a viewport using relative size, which makes it easier
  to merge a final plot into a viewport of different aspect ratio and
  size than expected, as the relative size will remain and not the
  absolute ones (if any).
- fix a bug of drawing error bars in ~T~ style, which did not take
  data scale correctly into account resulting in too large or too
  small "side" bars.
- add ~+~ and ~-~ between ~Coord1D~ and ~Quantity~ for the same kind
```