### PR TITLE
extend the `BackendKind` for explicit dummy backend

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,6 @@
+* v0.4.3
+- add ~bkDummy~ backend enum field to differentiate between none given
+  and dummy selected
 * v0.4.2
 - update LatexDSL package (PR #44 and further in #45)
 - handle tilde =~= in given filenames to expand to home directory

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -3298,7 +3298,8 @@ proc draw*(view: Viewport, filename: string, texOptions: TeXOptions = TeXOptions
   # be part of a `Backend` that's handed to a generic version of this procedure later.
   let filename = filename.expandTilde()
   let fType = parseFilename(filename)
-  let bck = fType.toBackend(texOptions)
+  let bck = if view.backend == bkNone: fType.toBackend(texOptions)
+            else: view.backend # Honor the backend if explcitly given
 
   template useBackend(backend: untyped): untyped =
     when declared(backend):
@@ -3313,11 +3314,12 @@ proc draw*(view: Viewport, filename: string, texOptions: TeXOptions = TeXOptions
       doAssert false, "The binary was compiled without the option to use the `" & $astToStr(backend) &
         "`. Please compile with `-d:use<Backend>` {Cairo, TikZ, Pixie} to activate it."
   case bck
-  of bkNone:  useBackend(DummyBackend)
+  of bkDummy: useBackend(DummyBackend)
   of bkCairo: useBackend(CairoBackend)
   of bkTikZ:  useBackend(TikZBackend)
   of bkVega:  {.warning: "Vega backend does not exist.".}; useBackend(DummyBackend)
   of bkPixie: useBackend(PixieBackend)
+  of bkNone: doAssert false, "Invalid branch. We determined the backend from the filename."
 
 when isMainModule:
 

--- a/src/ginger/backends.nim
+++ b/src/ginger/backends.nim
@@ -63,10 +63,10 @@ proc getTextExtent*(backend: BackendKind, text: string, font: Font): TextExtent 
         "`. Please compile with `-d:use<Backend>` {Cairo, TikZ, Pixie} to activate it."
 
   case backend
-  of bkCairo: useBackend(CairoBackend)
-  of bkTikZ:  useBackend(TikZBackend)
-  of bkPixie: useBackend(PixieBackend)
-  of bkNone:  useBackend(DummyBackend)
+  of bkCairo:         useBackend(CairoBackend)
+  of bkTikZ:          useBackend(TikZBackend)
+  of bkPixie:         useBackend(PixieBackend)
+  of bkNone, bkDummy: useBackend(DummyBackend)
   else: discard
 
 when isMainModule:

--- a/src/ginger/types.nim
+++ b/src/ginger/types.nim
@@ -9,7 +9,7 @@ const usePixie* {.booldefine.} = false
 
 type
   BackendKind* = enum
-    bkNone, bkCairo, bkVega, bkTikZ, bkPixie
+    bkNone, bkDummy, bkCairo, bkVega, bkTikZ, bkPixie
   FiletypeKind* = enum
     fkSvg, fkPng, fkPdf, fkVega, fkTeX
 


### PR DESCRIPTION
This makes it sane to handle the difference between no backend given and the dummy backend selected explicitly.