### PR TITLE
Fix TikZ regression of dropping .tex file

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,7 @@
+* v0.5.1
+- fix TikZ regression: write a ~.tex~ file if the user explicitly
+  requests a TeX file instead of doing nothing
+- change default tick label offset from 1.25 'M' height to 1.5 'M' height
 * v0.5.0
 - change internal DPI from 72.27 to 72
 - extend viewport by FileTypeKind field for TextExtent information,

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -2243,7 +2243,7 @@ const LabelOffset = 1.5
 template xLabelOriginOffset(view: Viewport, txt: string, fnt: Font, isSecondary = false): untyped =
   ## Required offset along the `y` axis for tick labels of the `x` axis!
   if not isSecondary:
-    # uses `W` as default
+    # uses `M` as default
     strHeight(view, -LabelOffset, fnt)
       .toRelative(length = some(pointWidth(view)))
   else:

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -2239,14 +2239,15 @@ proc ylabel*(view: Viewport,
                               isSecondary = isSecondary,
                               rotate = rotate)
 
+const LabelOffset = 1.5
 template xLabelOriginOffset(view: Viewport, txt: string, fnt: Font, isSecondary = false): untyped =
   ## Required offset along the `y` axis for tick labels of the `x` axis!
   if not isSecondary:
     # uses `W` as default
-    strHeight(view, -1.25, fnt)
+    strHeight(view, -LabelOffset, fnt)
       .toRelative(length = some(pointWidth(view)))
   else:
-    strHeight(view, 1.25, fnt)
+    strHeight(view, LabelOffset, fnt)
       .toRelative(length = some(pointWidth(view)))
 
 proc halfHeight(view: Viewport, txt: string, fnt: Font): Quantity =
@@ -2256,10 +2257,10 @@ proc halfHeight(view: Viewport, txt: string, fnt: Font): Quantity =
 template yLabelOriginOffset(view: Viewport, txt: string, fnt: Font, isSecondary = false): untyped =
   ## Required offset along the `y` axis for tick labels of the `x` axis!
   if not isSecondary:
-    (strHeight(view, 1.25, fnt).toPoints() + view.halfHeight(txt, fnt))
+    (strHeight(view, LabelOffset, fnt).toPoints() + view.halfHeight(txt, fnt))
       .toRelative(length = some(pointHeight(view)))
   else:
-    (strHeight(view, -1.25, fnt).toPoints() - view.halfHeight(txt, fnt))
+    (strHeight(view, -LabelOffset, fnt).toPoints() - view.halfHeight(txt, fnt))
       .toRelative(length = some(pointHeight(view)))
 
 proc setTextAlignKind(axKind: AxisKind,

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -482,7 +482,7 @@ proc destroy*(img: var BImage[TikZBackend]) =
   # get the path for the output file
   let path = img.fname.parentDir
   case img.fType
-  of fkTeX: discard # nothing to do
+  of fkTeX: writeFile(img.fname, body) # only write the TeX file, do not compile
   of fkPdf:
     compile(img.fname, body, path = path, fullBody = true, verbose = QuietTikZ)
   else: doAssert false


### PR DESCRIPTION
While changing to the LatexDSL compiler, we forgot to handle the case where the user explicitly asks for a .tex file. 

Also changes the default of 1.25 M height for the tick label spacing to 1.5. 1.25 was a bit too small.