### PR TITLE
TikZ improvements

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,10 @@
+* v0.5.2
+- also draw rectangle in addition to setting page color
+- invert ~QuietTikZ~ logic and let latex compilation output be quiet
+  by default.
+  Note: the only downside of being quiet by default is that we hide
+  TeX compilation errors. We need to handle this better in the future
+  using the TeXDaemon.
 * v0.5.1
 - fix TikZ regression: write a ~.tex~ file if the user explicitly
   requests a TeX file instead of doing nothing

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -2879,6 +2879,9 @@ proc drawRect[T](img: var BImage[T], gobj: GraphObject) =
     # the entire image no matter if there are overflows
     if gobj.name == "canvasBackground":
       img.drawBackground(gobj.style.get)
+      # *Also* apply our rectangle as background. GS and Inkscape like to ignore the background color
+      # if it's white by default
+      rect()
     else:
       rect()
 

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -474,7 +474,7 @@ proc initBImage*(_: typedesc[TikZBackend],
                                width: width, height: height,
                                fType: fType)
 
-const QuietTikZ {.booldefine.} = false
+const QuietTikZ {.booldefine.} = true
 proc destroy*(img: var BImage[TikZBackend]) =
   # write to file
   let body = backendTikZ.genTeXFile(img)

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -484,7 +484,7 @@ proc destroy*(img: var BImage[TikZBackend]) =
   case img.fType
   of fkTeX: writeFile(img.fname, body) # only write the TeX file, do not compile
   of fkPdf:
-    compile(img.fname, body, path = path, fullBody = true, verbose = QuietTikZ)
+    compile(img.fname, body, path = path, fullBody = true, verbose = not QuietTikZ)
   else: doAssert false
 
   # close the TeXDaemon


### PR DESCRIPTION
```
* v0.5.2
- also draw rectangle in addition to setting page color
- invert ~QuietTikZ~ logic and let latex compilation output be quiet
  by default.
  Note: the only downside of being quiet by default is that we hide
  TeX compilation errors. We need to handle this better in the future
  using the TeXDaemon.
```