### PR TITLE
More TikZ fixes for `bp` usage 

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,8 @@
+* v0.5.3
+- fix raster procedures on TikZ backend for ~bp~ units
+- allow to hand custom style to ~tickLabels~
+- fix circle radius for TikZ backend
+- fix multiline text with monospace font on TikZ backend
 * v0.5.2
 - also draw rectangle in addition to setting page color
 - invert ~QuietTikZ~ logic and let latex compilation output be quiet

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -2439,7 +2439,9 @@ proc tickLabels*(view: Viewport,
                  isSecondary = false,
                  rotate = none[float](),
                  margin = none[Coord1D](),
-                 alignToOverride = none[TextAlignKind]()
+                 alignToOverride = none[TextAlignKind](),
+                 style = none[Style](),
+                 tickKind: TickKind = tkOneSide
                 ): (seq[GraphObject], seq[GraphObject]) =
   ## Overload of `tickLabels`, which allows to define custom tick label
   ## texts for ticks at positions `tickPos`
@@ -2452,7 +2454,9 @@ proc tickLabels*(view: Viewport,
     let tick = view.initTick(axKind = axKind,
                              at = axisCoord(tickPos[i], axKind, isSecondary),
                              major = true,
-                             isSecondary = isSecondary)
+                             isSecondary = isSecondary,
+                             tickKind = tickKind,
+                             style = style)
     result[0][i] = tick
     result[1][i] = view.initTickLabel(tick = tick, font = mfont,
                                       labelTxt = tickLabels[i],

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -686,6 +686,7 @@ proc toRelative*(p: Coord1D,
       raise newException(ValueError, "Cannot convert " & $p.kind & " to relative without " &
         "a backend!")
     let extents = getTextExtent(p.backend, p.fType, p.text, p.font)
+    ## XXX: think again if we might want to include bearing and advance
     let relevantDim = if p.kind == ukStrWidth: extents.width #extents.x_bearing + extents.x_advance
                       else: extents.height #extents.y_advance - extents.y_bearing
     # TODO: assume we can only use `width` here. Maybe have to consider bearing too!
@@ -740,10 +741,10 @@ proc toPoints*(p: Coord1D,
     ## without bearing & advance the width / height will be off if spaces are involved
     let relevantDim = if p.kind == ukStrWidth:
                         if p.includeBearing: extents.width + extents.x_bearing
-                        else: extents.width
+                        else: extents.width #extents.x_bearing + extents.x_advance
                       else:
                         if p.includeBearing: extents.height + extents.y_bearing
-                        else: extents.height#extents.y_advance - extents.y_bearing
+                        else: extents.height #extents.y_advance - extents.y_bearing
     result = Coord1D(pos: p.pos * relevantDim,
                      kind: ukPoint)
 

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -2246,10 +2246,10 @@ template xLabelOriginOffset(view: Viewport, txt: string, fnt: Font, isSecondary 
   if not isSecondary:
     # uses `M` as default
     strHeight(view, -LabelOffset, fnt)
-      .toRelative(length = some(pointWidth(view)))
+      .toPoints
   else:
     strHeight(view, LabelOffset, fnt)
-      .toRelative(length = some(pointWidth(view)))
+      .toPoints
 
 proc halfHeight(view: Viewport, txt: string, fnt: Font): Quantity =
   result = view.getStrHeight(txt, fnt)
@@ -2259,10 +2259,10 @@ template yLabelOriginOffset(view: Viewport, txt: string, fnt: Font, isSecondary 
   ## Required offset along the `y` axis for tick labels of the `x` axis!
   if not isSecondary:
     (strHeight(view, LabelOffset, fnt).toPoints() + view.halfHeight(txt, fnt))
-      .toRelative(length = some(pointHeight(view)))
+      .toPoints
   else:
     (strHeight(view, -LabelOffset, fnt).toPoints() - view.halfHeight(txt, fnt))
-      .toRelative(length = some(pointHeight(view)))
+      .toPoints
 
 proc setTextAlignKind(axKind: AxisKind,
                       isSecondary = false,
@@ -2302,7 +2302,7 @@ proc initTickLabel(view: Viewport,
     let yOffset = if margin.isSome: margin.unsafeGet
                   else: yLabelOriginOffset(view, labelTxt, mfont, isSecondary)
     origin = Coord(x: loc.x,
-                   y: (loc.y + yOffset).toRelative)
+                   y: (loc.y.toPoints(length = some(pointHeight(view))) + yOffset).toRelative(length = some(pointHeight(view))))
     if gobjName == "tickLabel":
       gobjName = "x" & name
       if isSecondary:
@@ -2315,7 +2315,7 @@ proc initTickLabel(view: Viewport,
   of akY:
     let xOffset = if margin.isSome: margin.unsafeGet
                   else: xLabelOriginOffset(view, labelTxt, mfont, isSecondary)
-    origin = Coord(x: (loc.x + xOffset).toRelative,
+    origin = Coord(x: (loc.x.toPoints(length = some(pointWidth(view))) + xOffset).toRelative(length = some(pointWidth(view))),
                    y: loc.y)
     if gobjName == "tickLabel":
       gobjName = "y" & name

--- a/src/ginger/backendCairo.nim
+++ b/src/ginger/backendCairo.nim
@@ -195,7 +195,7 @@ proc drawText*(img: var BImage[CairoBackend], text: string, font: Font, at: Poin
       ctx.rotate(rotate.get(), (rotAtX, rotAtY))
     case alignKind
     of taLeft:
-      x = at.x
+      x = at.x - extents.x_bearing
       y = at.y - (extents.height / 2.0 + extents.y_bearing)
     of taCenter:
       x = at.x - (extents.width / 2.0 + extents.x_bearing)

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -303,15 +303,14 @@ proc drawRectangle*(img: var BImage[TikZBackend], left, bottom, width, height: f
   let sizePt = img.toTikZCoord((x: left + width, y: bottom + height), isLength = false)
   if style.gradient.isSome:
     let gradient = style.gradient.get
-    let heightRel = height / img.width.float
-    let sliceHeight = heightRel / (gradient.colors.len.float - 1)
-    var curBottom = atPt.y - heightRel
+    let sliceHeight = height / (gradient.colors.len.float) # - 1)
+    var curBottom = atPt.y - height
     for i, c in gradient.colors:
       let n = "color" & $i
       let atStr = (x: atPt.x, y: curBottom).toStrDirect # left bottom coords
       let sizeStr = (
         x: sizePt.x,
-        y: curBottom + sliceHeight + 1e-3               # add some ε for overlap
+        y: curBottom + sliceHeight + 0.5                # add some ε for overlap
       ).toStrDirect                                     # end coords
       let curColor = defColor(n, c)
       let curLineStyle = style.lineStyle(fillColor = n)
@@ -359,9 +358,9 @@ when useCairo and not defined(noCairo):
     imgC.destroy()
     # embedding a picture using a node places ``center`` of picture at `atStr` coord
     let atStr = img.toStr((x: left + width / 2.0, y: bottom + height / 2.0))
-    let w = width / img.width.float
+    let w = $width & "bp"
     latexAdd:
-      \node at `atStr` {\includegraphics[width = `w`\textwidth]{`tmpName`}}";"
+      \node at `atStr` {\includegraphics[width = `w`]{`tmpName`}}";"
 else:
   proc drawRaster*(img: var BImage[TikZBackend], left, bottom, width, height: float,
                    numX, numY: int,

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -105,7 +105,6 @@ proc applyStyle(text: string, font: Font): string =
       result = latex: # multi lines: embed in `tabular` environemnt with padding removed!
         tabular{"@{}l@{}"}:
           `multiline`
-      echo result
   else:
     result = text
 

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -82,6 +82,7 @@ proc nodeProperties(img: BImage[TikZBackend], at: Point, alignKind: TextAlignKin
   if result.len > 0:
     result = "[" & result & "]"
 
+from std / strutils import split, strip
 proc applyStyle(text: string, font: Font): string =
   ## Applies the correct style to the given text, depending on the font.
   if font.bold:
@@ -91,8 +92,20 @@ proc applyStyle(text: string, font: Font): string =
     # replace spaces by `\ ` to get explicit spaces where spaces are found to
     # get correct size for text with spaces.
     let text = text.replace(" ", r"\ ")
-    result = latex:
-      \texttt{`text`}
+    # if multiple lines, split them
+    if r"\\" notin text:
+      result = latex:
+        \texttt{`text`}
+    else:
+      var multiline = ""
+      for l in split(text.strip(chars = {'\n', '\\'}), r"\\"):
+        let nl = latex:
+          \texttt{`l`} "\\\\"
+        multiline.add nl
+      result = latex: # multi lines: embed in `tabular` environemnt with padding removed!
+        tabular{"@{}l@{}"}:
+          `multiline`
+      echo result
   else:
     result = text
 

--- a/src/ginger/backendTikZ.nim
+++ b/src/ginger/backendTikZ.nim
@@ -187,7 +187,7 @@ proc drawCircle*(img: var BImage[TikZBackend], center: Point, radius: float,
                  fillColor = color(0.0, 0.0, 0.0, 0.0),
                  rotateAngle: Option[(float, Point)] = none[(float, Point)]()) =
   let p = img.toStr(center)
-  let radius = $(radius / img.width.float) & "\\textwidth"# / img.width.float
+  let radius = $radius & "bp"
   let style = Style(lineWidth: lineWidth,
                     color: strokeColor,
                     fillColor: fillColor)

--- a/src/ginger/types.nim
+++ b/src/ginger/types.nim
@@ -148,7 +148,10 @@ type
       reOrigin*: Coord
       reWidth*: Quantity
       reHeight*: Quantity
-    of goRaster:
+    of goRaster: ## XXX: add option to somehow allow ggplotnim to store any plot as raster if too many
+                 ## objects are contained in it. Maybe add a filename argument that will instead be
+                 ## used? In ggplotnim could check if df.len > N, then produce PNG of only the
+                 ## plot viewport and then hand that as a raster?
       # raw pixel raster object, used for high pixel density heatmaps etc.
       rstOrigin*: Coord
       rstPixWidth*: Quantity


### PR DESCRIPTION
```
* v0.5.3
- fix raster procedures on TikZ backend for ~bp~ units
- allow to hand custom style to ~tickLabels~
- fix circle radius for TikZ backend
- fix multiline text with monospace font on TikZ backend
```