### PR TITLE
add fkDummy, fkNull to make sure file type kind always set

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,9 @@
+* v0.6.1
+- add ~fkNull~, ~fkDummy~ as ~FileTypeKind~ fields to make sure we
+  always use the correct file type kind as a target to determine the
+  text extents.
+- make ~dataAsBitmap~ do nothing when not compiled with Cairo support
+  (i.e. ~noCairo~ is set)  
 * v0.6.0
 - add option ~dataAsBitmap~ to draw Viewport to bitmap. Useful for
   plots with large amounts of data. The rest of the plot can remain a

--- a/src/ginger.nim
+++ b/src/ginger.nim
@@ -1809,6 +1809,7 @@ proc getStrHeight*(backend: BackendKind, fType: FileTypeKind, text: string, font
               backend: backend,
               text: text,
               font: font,
+              fType: fType,
               includeBearing: false)
     ).pos,
     unit = ukPoint

--- a/src/ginger/backends.nim
+++ b/src/ginger/backends.nim
@@ -54,8 +54,8 @@ proc toBackend*(fType: FiletypeKind, texOptions: TexOptions): BackendKind =
                bkCairo # extend for Pixie
   of fkVega: doAssert false # not supported
   of fkDummy: result = bkDummy
-  of fkNone:
-    raise newException(ValueError, "File type fkNone cannot be converted to a backend.")
+  of fkNull:
+    raise newException(ValueError, "File type `fkNull` cannot be converted to a backend.")
 
 proc getTextExtent*(backend: BackendKind, fType: FileTypeKind, text: string, font: Font): TextExtent =
   template useBackend(backend: untyped): untyped =

--- a/src/ginger/backends.nim
+++ b/src/ginger/backends.nim
@@ -53,6 +53,9 @@ proc toBackend*(fType: FiletypeKind, texOptions: TexOptions): BackendKind =
              else:
                bkCairo # extend for Pixie
   of fkVega: doAssert false # not supported
+  of fkDummy: result = bkDummy
+  of fkNone:
+    raise newException(ValueError, "File type fkNone cannot be converted to a backend.")
 
 proc getTextExtent*(backend: BackendKind, fType: FileTypeKind, text: string, font: Font): TextExtent =
   template useBackend(backend: untyped): untyped =

--- a/src/ginger/types.nim
+++ b/src/ginger/types.nim
@@ -12,7 +12,7 @@ type
   BackendKind* = enum
     bkNone, bkDummy, bkCairo, bkVega, bkTikZ, bkPixie
   FiletypeKind* = enum
-    fkNone, fkDummy, fkSvg, fkPng, fkPdf, fkVega, fkTeX
+    fkNull, fkDummy, fkSvg, fkPng, fkPdf, fkVega, fkTeX
 
   Point* = tuple[x, y: float]
   IPoint* = tuple[x, y: int]

--- a/src/ginger/types.nim
+++ b/src/ginger/types.nim
@@ -12,7 +12,7 @@ type
   BackendKind* = enum
     bkNone, bkDummy, bkCairo, bkVega, bkTikZ, bkPixie
   FiletypeKind* = enum
-    fkSvg, fkPng, fkPdf, fkVega, fkTeX
+    fkNone, fkDummy, fkSvg, fkPng, fkPdf, fkVega, fkTeX
 
   Point* = tuple[x, y: float]
   IPoint* = tuple[x, y: int]

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -87,6 +87,7 @@ suite "Coordinate transformations":
                      font: Font(family: "sans-serif",
                                 size: 16.0,
                                 color: black),
+                     fType: fkSvg,
                      backend: bkCairo)
 
     let c2 = Coord1D(pos: 0.3, kind: ukCentimeter)


### PR DESCRIPTION
And correct....


The first element of the `FileTypeKind` enum was `fkSvg`, which meant if we did not set the type, it would use that. That was indeed the case in some text extent related calls from ggplotnim. These could explain the CI failures on the ggplotnim PR https://github.com/Vindaar/ggplotnim/pull/176.